### PR TITLE
Re-enable clippy & fmt (also add helper scripts)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,23 +38,23 @@ jobs:
           key: ${{ runner.os }}-cargo-dev-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo build --all-targets
 
-  # clippy:
-  #   name: cargo clippy
-  #   needs: [build]
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: rui314/setup-mold@v1
-  #     - uses: dtolnay/rust-toolchain@stable
-  #     - run: rustup component add clippy
-  #     - uses: actions/cache@v3
-  #       with:
-  #         path: |
-  #           ./.cargo/.build
-  #           ./target
-  #           ~/.cargo
-  #         key: ${{ runner.os }}-cargo-dev-${{ hashFiles('**/Cargo.lock') }}
-  #     - run: cargo clippy --all
+  clippy:
+    name: cargo clippy
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: rui314/setup-mold@v1
+      - uses: dtolnay/rust-toolchain@stable
+      - run: rustup component add clippy
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ./.cargo/.build
+            ./target
+            ~/.cargo
+          key: ${{ runner.os }}-cargo-dev-${{ hashFiles('**/Cargo.lock') }}
+      - run: cargo clippy --all
 
   test-script:
     name: test-scripts

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,14 +92,14 @@ jobs:
       - run: cargo test
   
   
-  # # Things that don't need a cache
-  # fmt:
-  #   name: rustfmt
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: dtolnay/rust-toolchain@stable
-  #       with:
-  #         toolchain: nightly
-  #     - run: rustup component add rustfmt
-  #     - run: cargo fmt --all -- --check
+  # Things that don't need a cache
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: nightly
+      - run: rustup component add rustfmt
+      - run: cargo fmt --all -- --check

--- a/clippy.sh
+++ b/clippy.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# this file is an shorthand for the command below
+cargo clippy --all "$@"

--- a/fmt.sh
+++ b/fmt.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# this file is an shorthand for the command below, to not forget the nightly
+cargo +nightly fmt --all "$@"

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,9 +2,9 @@
 // error_generic_member_access https://github.com/rust-lang/rust/issues/99301
 // provide_any https://github.com/rust-lang/rust/issues/96024
 
-use std::{io::Error as ioError, path::Path};
 #[cfg(feature = "backtrace")]
 use std::backtrace::Backtrace;
+use std::{io::Error as ioError, path::Path};
 
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/src/file.rs
+++ b/src/file.rs
@@ -1,5 +1,5 @@
+use crate::{Error, IOErrorToError, Result};
 use std::path::PathBuf;
-use crate::{Result, IOErrorToError, Error};
 
 pub struct MarkedFile {
     pub file_contents: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,5 +284,5 @@ pub fn generate_files(
 
     mod_rs.write()?;
 
-    return Ok(());
+    Ok(())
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -234,11 +234,8 @@ fn handle_table_macro(
                             proc_macro2::TokenTree::Punct(punct) => {
                                 let char = punct.as_char();
 
-                                if char == '#' {
-                                    // Skip any additional #[]
-                                    continue;
-                                } else if char == '-' || char == '>' {
-                                    // nothing for arrow
+                                if char == '#' || char == '-' || char == '>' {
+                                    // nothing for arrow or any additional #[]
                                     continue;
                                 } else if char == ','
                                     && column_name.is_some()


### PR DESCRIPTION
This PR changes CI to be more maintainable, and re-enables all disabled staged, in more detail:

- re-enable `clippy` and `rustfmt` stages
- ~~change all action versions to be less specific (they are now more up-to-date automatically)~~
- ~~replace `action-rs` scripts with raw or equivalents (because they are unmaintained and deprecated)~~
- ~~change stage and workflow names to better represent the stages~~
- ~~remove `check` stage, because it is already covered by `build`~~
- ~~run workflows on all branches~~
- ~~run workflow when itself is updated~~
- add helper script `fmt.sh` and `clippy.sh` for easy common usage
- apply `fmt.sh` and error from `clippy.sh`