### PR TITLE
Update CI things (without formatting and clippy)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,23 +38,6 @@ jobs:
           key: ${{ runner.os }}-cargo-dev-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo build --all-targets
 
-  check:
-    name: cargo check
-    needs: [build]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: rui314/setup-mold@v1
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ./.cargo/.build
-            ./target
-            ~/.cargo
-          key: ${{ runner.os }}-cargo-dev-${{ hashFiles('**/Cargo.lock') }}
-      - run: cargo check --all
-
   # clippy:
   #   name: cargo clippy
   #   needs: [build]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,21 +24,21 @@ jobs:
     name: cargo build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3
       - uses: rui314/setup-mold@v1
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions/cache@v3.2.4
+      - uses: actions/cache@v3
         with:
           path: |
             ./.cargo/.build
             ./target
             ~/.cargo
           key: ${{ runner.os }}-cargo-dev-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/cargo@v1.0.3
+      - uses: actions-rs/cargo@v1
         with:
           command: build
 
@@ -47,21 +47,21 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3
       - uses: rui314/setup-mold@v1
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions/cache@v3.2.4
+      - uses: actions/cache@v3
         with:
           path: |
             ./.cargo/.build
             ./target
             ~/.cargo
           key: ${{ runner.os }}-cargo-dev-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/cargo@v1.0.3
+      - uses: actions-rs/cargo@v1
         with:
           command: check
 
@@ -70,22 +70,22 @@ jobs:
   #   needs: [build]
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v3.3.0
+  #     - uses: actions/checkout@v3
   #     - uses: rui314/setup-mold@v1
-  #     - uses: actions-rs/toolchain@v1.0.7
+  #     - uses: actions-rs/toolchain@v1
   #       with:
   #         profile: minimal
   #         toolchain: stable
   #         override: true
   #     - run: rustup component add clippy
-  #     - uses: actions/cache@v3.2.4
+  #     - uses: actions/cache@v3
   #       with:
   #         path: |
   #           ./.cargo/.build
   #           ./target
   #           ~/.cargo
   #         key: ${{ runner.os }}-cargo-dev-${{ hashFiles('**/Cargo.lock') }}
-  #     - uses: actions-rs/cargo@v1.0.3
+  #     - uses: actions-rs/cargo@v1
   #       with:
   #         command: clippy
   #         args: --all
@@ -95,14 +95,14 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3
       - uses: rui314/setup-mold@v1
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions/cache@v3.2.4
+      - uses: actions/cache@v3
         with:
           path: |
             ./.cargo/.build
@@ -117,21 +117,21 @@ jobs:
     name: cargo test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
+      - uses: actions/checkout@v3
       - uses: rui314/setup-mold@v1
-      - uses: actions-rs/toolchain@v1.0.7
+      - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
           toolchain: stable
           override: true
-      - uses: actions/cache@v3.2.4
+      - uses: actions/cache@v3
         with:
           path: |
             ./.cargo/.build
             ./target
             ~/.cargo
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/cargo@v1.0.3
+      - uses: actions-rs/cargo@v1
         with:
           command: test
   
@@ -141,14 +141,14 @@ jobs:
   #   name: rustfmt
   #   runs-on: ubuntu-latest
   #   steps:
-  #     - uses: actions/checkout@v3.3.0
-  #     - uses: actions-rs/toolchain@v1.0.7
+  #     - uses: actions/checkout@v3
+  #     - uses: actions-rs/toolchain@v1
   #       with:
   #         profile: minimal
   #         toolchain: stable
   #         override: true
   #     - run: rustup component add rustfmt
-  #     - uses: actions-rs/cargo@v1.0.3
+  #     - uses: actions-rs/cargo@v1
   #       with:
   #         command: fmt
   #         args: --all -- --check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,9 +36,7 @@ jobs:
             ./target
             ~/.cargo
           key: ${{ runner.os }}-cargo-dev-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/cargo@v1
-        with:
-          command: build
+      - run: cargo build --all-targets
 
   check:
     name: cargo check
@@ -55,9 +53,7 @@ jobs:
             ./target
             ~/.cargo
           key: ${{ runner.os }}-cargo-dev-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - run: cargo check --all
 
   # clippy:
   #   name: cargo clippy
@@ -75,10 +71,7 @@ jobs:
   #           ./target
   #           ~/.cargo
   #         key: ${{ runner.os }}-cargo-dev-${{ hashFiles('**/Cargo.lock') }}
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: clippy
-  #         args: --all
+  #     - run: cargo clippy --all
 
   test-script:
     name: test-scripts
@@ -113,9 +106,7 @@ jobs:
             ./target
             ~/.cargo
           key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - run: cargo test
   
   
   # # Things that don't need a cache
@@ -128,7 +119,4 @@ jobs:
   #       with:
   #         toolchain: nightly
   #     - run: rustup component add rustfmt
-  #     - uses: actions-rs/cargo@v1
-  #       with:
-  #         command: fmt
-  #         args: --all -- --check
+  #     - run: cargo fmt --all -- --check

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,12 +2,14 @@ name: Continuous Integration
 on:
   workflow_dispatch:
   push:
-    paths: 
+    paths:
+      - ".github/workflows/CI.yml"
       - "**.rs"
       - "Cargo.lock"
       - "Cargo.toml"
   pull_request:
-    paths: 
+    paths:
+      - ".github/workflows/CI.yml"
       - "**.rs"
       - "Cargo.lock"
       - "Cargo.toml"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,8 +2,6 @@ name: Rust Continuous Integration
 on:
   workflow_dispatch:
   push:
-    branches: 
-      - "main"
     paths: 
       - "**.rs"
       - "Cargo.lock"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,4 +1,4 @@
-name: Rust Continuous Integration
+name: Continuous Integration
 on:
   workflow_dispatch:
   push:
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   build:
-    name: Build and Initialize profile.dev Cache
+    name: cargo build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.3.0
@@ -43,7 +43,7 @@ jobs:
           command: build
 
   check:
-    name: Check
+    name: cargo check
     needs: [build]
     runs-on: ubuntu-latest
     steps:
@@ -66,7 +66,7 @@ jobs:
           command: check
 
   # clippy:
-  #   name: Clippy
+  #   name: cargo clippy
   #   needs: [build]
   #   runs-on: ubuntu-latest
   #   steps:
@@ -88,7 +88,7 @@ jobs:
   #     - uses: actions-rs/cargo@v1.0.3
   #       with:
   #         command: clippy
-  #         args: -- -D warnings
+  #         args: --all
 
   test-script:
     name: test-scripts
@@ -114,7 +114,7 @@ jobs:
       
   # things that use the cargo-test cache
   test:
-    name: Test Suite and Initialize profile.test Cache
+    name: cargo test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3.3.0
@@ -138,7 +138,7 @@ jobs:
   
   # # Things that don't need a cache
   # fmt:
-  #   name: Rustfmt
+  #   name: rustfmt
   #   runs-on: ubuntu-latest
   #   steps:
   #     - uses: actions/checkout@v3.3.0

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -26,11 +26,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: rui314/setup-mold@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v3
         with:
           path: |
@@ -49,11 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: rui314/setup-mold@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v3
         with:
           path: |
@@ -72,11 +64,7 @@ jobs:
   #   steps:
   #     - uses: actions/checkout@v3
   #     - uses: rui314/setup-mold@v1
-  #     - uses: actions-rs/toolchain@v1
-  #       with:
-  #         profile: minimal
-  #         toolchain: stable
-  #         override: true
+  #     - uses: dtolnay/rust-toolchain@stable
   #     - run: rustup component add clippy
   #     - uses: actions/cache@v3
   #       with:
@@ -97,11 +85,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: rui314/setup-mold@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v3
         with:
           path: |
@@ -119,11 +103,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: rui314/setup-mold@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v3
         with:
           path: |
@@ -142,11 +122,9 @@ jobs:
   #   runs-on: ubuntu-latest
   #   steps:
   #     - uses: actions/checkout@v3
-  #     - uses: actions-rs/toolchain@v1
+  #     - uses: dtolnay/rust-toolchain@stable
   #       with:
-  #         profile: minimal
-  #         toolchain: stable
-  #         override: true
+  #         toolchain: nightly
   #     - run: rustup component add rustfmt
   #     - uses: actions-rs/cargo@v1
   #       with:


### PR DESCRIPTION
This PR is a subset of changes from #58, without re-enabling some jobs until further discussion

This PR changes CI to be more maintainable, in more detail:

- change all action versions to be less specific (they are now more up-to-date automatically)
- replace `action-rs` scripts with raw or equivalents (because they are unmaintained and deprecated)
- change stage and workflow names to better represent the stages
- remove `check` stage, because it is already covered by `build`
- run workflows on all branches
- run workflow when itself is updated