### PR TITLE
feat: replace "inflector" with "heck" also remove "to_singular"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - replace `structopt` with `clap`
 - add subcommand to generate shell completions
 - function `generate_files` now takes in `&Path`s instead of `PathBuf`s
+- remove `to_singular` name generations
+- replace dependency `Inflector` with `heck`
 
 ## 0.0.16
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,25 +3,6 @@
 version = 3
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-dependencies = [
- "lazy_static",
- "regex",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "0.7.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f55bd91a0978cbfd91c457a164bab8b4001c833b7f323132c0a4e1922dd44e"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anstream"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,9 +126,9 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 name = "dsync"
 version = "0.0.17-beta"
 dependencies = [
- "Inflector",
  "clap",
  "clap_complete",
+ "heck",
  "indoc",
  "proc-macro2",
  "syn 1.0.107",
@@ -205,12 +186,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -221,12 +196,6 @@ name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
-name = "memchr"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "once_cell"
@@ -251,23 +220,6 @@ checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "regex"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "rustix"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ clap_complete = "4.3"
 syn = { version = "1", features = ["extra-traits", "full"] }
 proc-macro2 = "1"
 indoc = "2.0.0"
-Inflector = { version = "0.11.4" }
+heck = "0.4" # same case converter diesel uses
 thiserror = "1.0"
 
 [lib]

--- a/src/code.rs
+++ b/src/code.rs
@@ -1,5 +1,5 @@
+use heck::{ToPascalCase, ToSnakeCase};
 use indoc::indoc;
-use inflector::Inflector;
 
 use crate::parser::{ParsedTableMacro, FILE_SIGNATURE};
 use crate::{GenerationConfig, TableOptions};
@@ -232,7 +232,7 @@ impl<'a> Struct<'a> {
             .map(|fk| {
                 format!(
                     ", belongs_to({foreign_table_name}, foreign_key={join_column})",
-                    foreign_table_name = fk.0.to_string().to_pascal_case().to_singular(),
+                    foreign_table_name = fk.0.to_string().to_pascal_case(),
                     join_column = fk.1
                 )
             })
@@ -488,7 +488,7 @@ fn build_imports(table: &ParsedTableMacro, config: &GenerationConfig) -> String 
             format!(
                 "use {model_path}{foreign_table_name_model}::{singular_struct_name};",
                 foreign_table_name_model = fk.0.to_string().to_snake_case().to_lowercase(),
-                singular_struct_name = fk.0.to_string().to_pascal_case().to_singular(),
+                singular_struct_name = fk.0.to_string().to_pascal_case(),
                 model_path = config.model_path
             )
         })

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,4 @@
-use inflector::Inflector;
+use heck::ToPascalCase;
 use syn::Ident;
 use syn::Item::Macro;
 
@@ -319,11 +319,7 @@ fn handle_table_macro(
             .ok_or(Error::unsupported_schema_format(
                 "Could not extract table name from schema file",
             ))?,
-        struct_name: table_name_ident
-            .unwrap()
-            .to_string()
-            .to_pascal_case()
-            .to_singular(),
+        struct_name: table_name_ident.unwrap().to_string().to_pascal_case(),
         columns: table_columns,
         primary_key_columns: table_primary_key_idents,
         foreign_keys: vec![],

--- a/test/autogenerated_all/models/todos/generated.rs
+++ b/test/autogenerated_all/models/todos/generated.rs
@@ -10,7 +10,7 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
-pub struct Todo {
+pub struct Todos {
     pub id: i32,
     pub created_at: chrono::NaiveDateTime,
 }
@@ -18,7 +18,7 @@ pub struct Todo {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
 #[diesel(table_name=todos)]
-pub struct UpdateTodo {
+pub struct UpdateTodos {
     pub created_at: Option<chrono::NaiveDateTime>,
 }
 
@@ -33,7 +33,7 @@ pub struct PaginationResult<T> {
     pub num_pages: i64,
 }
 
-impl Todo {
+impl Todos {
 
     pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
@@ -65,7 +65,7 @@ impl Todo {
         })
     }
 
-    pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodo) -> QueryResult<Self> {
+    pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)

--- a/test/autogenerated_attributes/models/todos/generated.rs
+++ b/test/autogenerated_attributes/models/todos/generated.rs
@@ -10,20 +10,20 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
-pub struct Todo {
+pub struct Todos {
     pub id: i32,
     pub created_at: chrono::NaiveDateTime,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable)]
 #[diesel(table_name=todos)]
-pub struct CreateTodo {
+pub struct CreateTodos {
     pub id: i32,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
 #[diesel(table_name=todos)]
-pub struct UpdateTodo {
+pub struct UpdateTodos {
     pub created_at: Option<chrono::NaiveDateTime>,
 }
 
@@ -38,9 +38,9 @@ pub struct PaginationResult<T> {
     pub num_pages: i64,
 }
 
-impl Todo {
+impl Todos {
 
-    pub fn create(db: &mut ConnectionType, item: &CreateTodo) -> QueryResult<Self> {
+    pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db)
@@ -70,7 +70,7 @@ impl Todo {
         })
     }
 
-    pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodo) -> QueryResult<Self> {
+    pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)

--- a/test/autogenerated_primary_keys/models/todos/generated.rs
+++ b/test/autogenerated_primary_keys/models/todos/generated.rs
@@ -10,20 +10,20 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
-pub struct Todo {
+pub struct Todos {
     pub id: i32,
     pub text: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
 #[diesel(table_name=todos)]
-pub struct CreateTodo {
+pub struct CreateTodos {
     pub text: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
 #[diesel(table_name=todos)]
-pub struct UpdateTodo {
+pub struct UpdateTodos {
     pub text: Option<String>,
 }
 
@@ -38,9 +38,9 @@ pub struct PaginationResult<T> {
     pub num_pages: i64,
 }
 
-impl Todo {
+impl Todos {
 
-    pub fn create(db: &mut ConnectionType, item: &CreateTodo) -> QueryResult<Self> {
+    pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db)
@@ -70,7 +70,7 @@ impl Todo {
         })
     }
 
-    pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodo) -> QueryResult<Self> {
+    pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)

--- a/test/cleanup_generated_content/models/todos/generated.rs
+++ b/test/cleanup_generated_content/models/todos/generated.rs
@@ -10,7 +10,7 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
-pub struct Todo {
+pub struct Todos {
     pub id: i32,
     pub text: String,
     pub completed: bool,
@@ -20,7 +20,7 @@ pub struct Todo {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
 #[diesel(table_name=todos)]
-pub struct CreateTodo {
+pub struct CreateTodos {
     pub id: i32,
     pub text: String,
     pub completed: bool,
@@ -28,7 +28,7 @@ pub struct CreateTodo {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
 #[diesel(table_name=todos)]
-pub struct UpdateTodo {
+pub struct UpdateTodos {
     pub text: Option<String>,
     pub completed: Option<bool>,
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
@@ -46,9 +46,9 @@ pub struct PaginationResult<T> {
     pub num_pages: i64,
 }
 
-impl Todo {
+impl Todos {
 
-    pub fn create(db: &mut ConnectionType, item: &CreateTodo) -> QueryResult<Self> {
+    pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db)
@@ -78,7 +78,7 @@ impl Todo {
         })
     }
 
-    pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodo) -> QueryResult<Self> {
+    pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)

--- a/test/manual_primary_keys/models/todos/generated.rs
+++ b/test/manual_primary_keys/models/todos/generated.rs
@@ -10,13 +10,13 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
-pub struct Todo {
+pub struct Todos {
     pub id: i32,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable)]
 #[diesel(table_name=todos)]
-pub struct CreateTodo {
+pub struct CreateTodos {
     pub id: i32,
 }
 
@@ -32,9 +32,9 @@ pub struct PaginationResult<T> {
     pub num_pages: i64,
 }
 
-impl Todo {
+impl Todos {
 
-    pub fn create(db: &mut ConnectionType, item: &CreateTodo) -> QueryResult<Self> {
+    pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db)

--- a/test/multiple_primary_keys/models/users/generated.rs
+++ b/test/multiple_primary_keys/models/users/generated.rs
@@ -10,7 +10,7 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
 #[diesel(table_name=users, primary_key(name,address))]
-pub struct User {
+pub struct Users {
     pub name: String,
     pub address: String,
     pub secret: String,
@@ -18,7 +18,7 @@ pub struct User {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
 #[diesel(table_name=users)]
-pub struct CreateUser {
+pub struct CreateUsers {
     pub name: String,
     pub address: String,
     pub secret: String,
@@ -26,7 +26,7 @@ pub struct CreateUser {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
 #[diesel(table_name=users)]
-pub struct UpdateUser {
+pub struct UpdateUsers {
     pub secret: Option<String>,
 }
 
@@ -41,9 +41,9 @@ pub struct PaginationResult<T> {
     pub num_pages: i64,
 }
 
-impl User {
+impl Users {
 
-    pub fn create(db: &mut ConnectionType, item: &CreateUser) -> QueryResult<Self> {
+    pub fn create(db: &mut ConnectionType, item: &CreateUsers) -> QueryResult<Self> {
         use crate::schema::users::dsl::*;
 
         insert_into(users).values(item).get_result::<Self>(db)
@@ -73,7 +73,7 @@ impl User {
         })
     }
 
-    pub fn update(db: &mut ConnectionType, param_name: String, param_address: String, item: &UpdateUser) -> QueryResult<Self> {
+    pub fn update(db: &mut ConnectionType, param_name: String, param_address: String, item: &UpdateUsers) -> QueryResult<Self> {
         use crate::schema::users::dsl::*;
 
         diesel::update(users.filter(name.eq(param_name)).filter(address.eq(param_address))).set(item).get_result(db)

--- a/test/simple_table/models/todos/generated.rs
+++ b/test/simple_table/models/todos/generated.rs
@@ -10,7 +10,7 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
-pub struct Todo {
+pub struct Todos {
     pub id: i32,
     pub unsigned: u32,
     pub unsigned_nullable: Option<u32>,
@@ -23,7 +23,7 @@ pub struct Todo {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
 #[diesel(table_name=todos)]
-pub struct CreateTodo {
+pub struct CreateTodos {
     pub unsigned: u32,
     pub unsigned_nullable: Option<u32>,
     pub text: String,
@@ -33,7 +33,7 @@ pub struct CreateTodo {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
 #[diesel(table_name=todos)]
-pub struct UpdateTodo {
+pub struct UpdateTodos {
     pub unsigned: Option<u32>,
     pub unsigned_nullable: Option<Option<u32>>,
     pub text: Option<String>,
@@ -54,9 +54,9 @@ pub struct PaginationResult<T> {
     pub num_pages: i64,
 }
 
-impl Todo {
+impl Todos {
 
-    pub fn create(db: &mut ConnectionType, item: &CreateTodo) -> QueryResult<Self> {
+    pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db)
@@ -86,7 +86,7 @@ impl Todo {
         })
     }
 
-    pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodo) -> QueryResult<Self> {
+    pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)

--- a/test/simple_table_async/models/todos/generated.rs
+++ b/test/simple_table_async/models/todos/generated.rs
@@ -11,7 +11,7 @@ type ConnectionType = diesel_async::pooled_connection::deadpool::Object<diesel_a
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
-pub struct Todo {
+pub struct Todos {
     pub id: i32,
     pub unsigned: u32,
     pub text: String,
@@ -22,7 +22,7 @@ pub struct Todo {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
 #[diesel(table_name=todos)]
-pub struct CreateTodo {
+pub struct CreateTodos {
     pub unsigned: u32,
     pub text: String,
     pub completed: bool,
@@ -30,7 +30,7 @@ pub struct CreateTodo {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
 #[diesel(table_name=todos)]
-pub struct UpdateTodo {
+pub struct UpdateTodos {
     pub unsigned: Option<u32>,
     pub text: Option<String>,
     pub completed: Option<bool>,
@@ -49,9 +49,9 @@ pub struct PaginationResult<T> {
     pub num_pages: i64,
 }
 
-impl Todo {
+impl Todos {
 
-    pub async fn create(db: &mut ConnectionType, item: &CreateTodo) -> QueryResult<Self> {
+    pub async fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db).await
@@ -81,7 +81,7 @@ impl Todo {
         })
     }
 
-    pub async fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodo) -> QueryResult<Self> {
+    pub async fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db).await

--- a/test/simple_table_custom_schema_path/models/todos/generated.rs
+++ b/test/simple_table_custom_schema_path/models/todos/generated.rs
@@ -10,7 +10,7 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
-pub struct Todo {
+pub struct Todos {
     pub id: i32,
     pub unsigned: u32,
     pub text: String,
@@ -21,7 +21,7 @@ pub struct Todo {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
 #[diesel(table_name=todos)]
-pub struct CreateTodo {
+pub struct CreateTodos {
     pub unsigned: u32,
     pub text: String,
     pub completed: bool,
@@ -29,7 +29,7 @@ pub struct CreateTodo {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
 #[diesel(table_name=todos)]
-pub struct UpdateTodo {
+pub struct UpdateTodos {
     pub unsigned: Option<u32>,
     pub text: Option<String>,
     pub completed: Option<bool>,
@@ -48,9 +48,9 @@ pub struct PaginationResult<T> {
     pub num_pages: i64,
 }
 
-impl Todo {
+impl Todos {
 
-    pub fn create(db: &mut ConnectionType, item: &CreateTodo) -> QueryResult<Self> {
+    pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::data::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db)
@@ -80,7 +80,7 @@ impl Todo {
         })
     }
 
-    pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodo) -> QueryResult<Self> {
+    pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::data::schema::todos::dsl::*;
 
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)

--- a/test/simple_table_no_crud/models/todos/generated.rs
+++ b/test/simple_table_no_crud/models/todos/generated.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
-pub struct Todo {
+pub struct Todos {
     pub id: i32,
     pub unsigned: u32,
     pub text: String,
@@ -17,7 +17,7 @@ pub struct Todo {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
 #[diesel(table_name=todos)]
-pub struct CreateTodo {
+pub struct CreateTodos {
     pub unsigned: u32,
     pub text: String,
     pub completed: bool,
@@ -25,7 +25,7 @@ pub struct CreateTodo {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
 #[diesel(table_name=todos)]
-pub struct UpdateTodo {
+pub struct UpdateTodos {
     pub unsigned: Option<u32>,
     pub text: Option<String>,
     pub completed: Option<bool>,

--- a/test/simple_table_no_serde/models/todos/generated.rs
+++ b/test/simple_table_no_serde/models/todos/generated.rs
@@ -10,7 +10,7 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 
 #[derive(Debug, Clone, Queryable, Insertable, AsChangeset, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
-pub struct Todo {
+pub struct Todos {
     pub id: i32,
     pub unsigned: u32,
     pub text: String,
@@ -21,7 +21,7 @@ pub struct Todo {
 
 #[derive(Debug, Clone, Queryable, Insertable, AsChangeset)]
 #[diesel(table_name=todos)]
-pub struct CreateTodo {
+pub struct CreateTodos {
     pub unsigned: u32,
     pub text: String,
     pub completed: bool,
@@ -29,7 +29,7 @@ pub struct CreateTodo {
 
 #[derive(Debug, Clone, Queryable, Insertable, AsChangeset, Default)]
 #[diesel(table_name=todos)]
-pub struct UpdateTodo {
+pub struct UpdateTodos {
     pub unsigned: Option<u32>,
     pub text: Option<String>,
     pub completed: Option<bool>,
@@ -48,9 +48,9 @@ pub struct PaginationResult<T> {
     pub num_pages: i64,
 }
 
-impl Todo {
+impl Todos {
 
-    pub fn create(db: &mut ConnectionType, item: &CreateTodo) -> QueryResult<Self> {
+    pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db)
@@ -80,7 +80,7 @@ impl Todo {
         })
     }
 
-    pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodo) -> QueryResult<Self> {
+    pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)

--- a/test/use_statements/models/fang_tasks/generated.rs
+++ b/test/use_statements/models/fang_tasks/generated.rs
@@ -10,7 +10,7 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
 #[diesel(table_name=fang_tasks, primary_key(id))]
-pub struct FangTask {
+pub struct FangTasks {
     pub id: uuid::Uuid,
     pub metadata: serde_json::Value,
     pub error_message: Option<String>,
@@ -25,7 +25,7 @@ pub struct FangTask {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
 #[diesel(table_name=fang_tasks)]
-pub struct CreateFangTask {
+pub struct CreateFangTasks {
     pub id: uuid::Uuid,
     pub metadata: serde_json::Value,
     pub error_message: Option<String>,
@@ -40,7 +40,7 @@ pub struct CreateFangTask {
 
 #[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
 #[diesel(table_name=fang_tasks)]
-pub struct UpdateFangTask {
+pub struct UpdateFangTasks {
     pub metadata: Option<serde_json::Value>,
     pub error_message: Option<Option<String>>,
     pub state: Option<crate::schema::sql_types::FangTaskState>,
@@ -63,9 +63,9 @@ pub struct PaginationResult<T> {
     pub num_pages: i64,
 }
 
-impl FangTask {
+impl FangTasks {
 
-    pub fn create(db: &mut ConnectionType, item: &CreateFangTask) -> QueryResult<Self> {
+    pub fn create(db: &mut ConnectionType, item: &CreateFangTasks) -> QueryResult<Self> {
         use crate::schema::fang_tasks::dsl::*;
 
         insert_into(fang_tasks).values(item).get_result::<Self>(db)
@@ -95,7 +95,7 @@ impl FangTask {
         })
     }
 
-    pub fn update(db: &mut ConnectionType, param_id: uuid::Uuid, item: &UpdateFangTask) -> QueryResult<Self> {
+    pub fn update(db: &mut ConnectionType, param_id: uuid::Uuid, item: &UpdateFangTasks) -> QueryResult<Self> {
         use crate::schema::fang_tasks::dsl::*;
 
         diesel::update(fang_tasks.filter(id.eq(param_id))).set(item).get_result(db)


### PR DESCRIPTION
re #56 

This PR switches from `Inflector` to `heck` and removes the `to_singular` usages.

`Inflector` as been last updated over 4 years ago and `heck` became the "defacto standard" for case conversions.
Also removed `to_singular` usage because it is not supported by `heck` and from my testing does not produce great names, example:
- table `media` would end up as `Medum`
- table `consume_status` would end up as `ConsumeStatu`
- table `consumed_via` would end up as `ConsumedVum`

Note: [`heck` is also used by diesel-cli](https://github.com/diesel-rs/diesel/blob/cf77884f01c34cbca8b1a4ee34d6b683131074d5/diesel_cli/Cargo.toml#L26)
EDIT: now that #64 is merged, i would note that `clap` also uses `heck`, so it would remove 1 dependency from being build