### PR TITLE
Fix support for unsigned on nullable fields

### DIFF
--- a/src/code.rs
+++ b/src/code.rs
@@ -149,12 +149,15 @@ impl<'a> Struct<'a> {
             })
             .map(|c| {
                 let name = c.name.to_string();
-                let base_type = if c.is_nullable {
-                    format!("Option<{}>", c.ty)
-                } else if c.is_unsigned {
+                let base_type = if c.is_unsigned {
                     c.ty.replace('i', "u")
                 } else {
                     c.ty.clone()
+                };
+                let base_type = if c.is_nullable {
+                    format!("Option<{}>", base_type)
+                } else {
+                    base_type
                 };
                 let mut is_optional = false;
 

--- a/test/simple_table/models/todos/generated.rs
+++ b/test/simple_table/models/todos/generated.rs
@@ -13,6 +13,7 @@ type Connection = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager
 pub struct Todo {
     pub id: i32,
     pub unsigned: u32,
+    pub unsigned_nullable: Option<u32>,
     pub text: String,
     pub completed: bool,
     pub type_: String,
@@ -24,6 +25,7 @@ pub struct Todo {
 #[diesel(table_name=todos)]
 pub struct CreateTodo {
     pub unsigned: u32,
+    pub unsigned_nullable: Option<u32>,
     pub text: String,
     pub completed: bool,
     pub type_: String,
@@ -33,6 +35,7 @@ pub struct CreateTodo {
 #[diesel(table_name=todos)]
 pub struct UpdateTodo {
     pub unsigned: Option<u32>,
+    pub unsigned_nullable: Option<Option<u32>>,
     pub text: Option<String>,
     pub completed: Option<bool>,
     pub type_: Option<String>,

--- a/test/simple_table/schema.rs
+++ b/test/simple_table/schema.rs
@@ -2,6 +2,7 @@ diesel::table! {
     todos (id) {
         id -> Int4,
         unsigned -> Unsigned<Integer>,
+        unsigned_nullable -> Nullable<Unsigned<Integer>>,
         text -> Text,
         completed -> Bool,
         #[sql_name = "type"]


### PR DESCRIPTION
The unsigned support introduced in
b41e14afc979ac144534e3d352bb8249f54fa967#r125954859 was incomplete as it did not cover the case where the unsigned field also is nullable. This change updates the code to convert the base type to unsigned in both cases.

Fixes: https://github.com/Wulf/dsync/issues/65