### PR TITLE
chore(workflows/CI): re-enable ci runs on pull requests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,7 @@
 name: Continuous Integration
-on: push
+on: 
+  push:
+  pull_request:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This PR changes so that the CI runs again on pull requests, which was changed by 58f08326fa42ce4b98b7f312cdca228f9f282cf3