### PR TITLE
`once-common-structs` and `once-connection-type`

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -98,6 +98,10 @@ pub struct MainOptions {
     /// Generate common structs only once in a "common.rs" file
     #[arg(long = "once-common-structs")]
     pub once_common_structs: bool,
+
+    /// Generate the "ConnectionType" type only once in a "common.rs" file
+    #[arg(long = "once-connection-type")]
+    pub once_connection_type: bool,
 }
 
 #[derive(Debug, ValueEnum, Clone, PartialEq, Default)]
@@ -198,6 +202,7 @@ fn actual_main() -> dsync::Result<()> {
             schema_path: args.schema_path,
             model_path: args.model_path,
             once_common_structs: args.once_common_structs,
+            once_connection_type: args.once_connection_type,
         },
     )?;
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -94,6 +94,10 @@ pub struct MainOptions {
     /// Only Generate a single model file instead of a directory with "mod.rs" and "generated.rs"
     #[arg(long = "single-model-file")]
     pub single_model_file: bool,
+
+    /// Generate common structs only once in a "common.rs" file
+    #[arg(long = "once-common-structs")]
+    pub once_common_structs: bool,
 }
 
 #[derive(Debug, ValueEnum, Clone, PartialEq, Default)]
@@ -193,6 +197,7 @@ fn actual_main() -> dsync::Result<()> {
             connection_type: args.connection_type,
             schema_path: args.schema_path,
             model_path: args.model_path,
+            once_common_structs: args.once_common_structs,
         },
     )?;
 

--- a/src/code.rs
+++ b/src/code.rs
@@ -507,6 +507,14 @@ pub struct PaginationResult<T> {{
     )
 }
 
+/// Generate connection-type type
+pub fn generate_connection_type(config: &GenerationConfig) -> String {
+    format!(
+        "\ntype ConnectionType = {connection_type};",
+        connection_type = config.connection_type,
+    )
+}
+
 /// Generate all imports for the struct file that are required
 fn build_imports(table: &ParsedTableMacro, config: &GenerationConfig) -> String {
     let table_options = config.table(&table.name.to_string());
@@ -547,16 +555,13 @@ fn build_imports(table: &ParsedTableMacro, config: &GenerationConfig) -> String 
         ""
     };
 
-    let connection_type_alias = if table_options.get_fns() {
-        format!(
-            "\ntype ConnectionType = {connection_type};",
-            connection_type = config.connection_type,
-        )
+    let connection_type_alias = if table_options.get_fns() && !config.once_connection_type {
+        generate_connection_type(config)
     } else {
         "".to_string()
     };
 
-    let common_structs_imports = if config.once_common_structs {
+    let common_structs_imports = if config.once_common_structs || config.once_connection_type {
         format!("\nuse {}common::*;", config.model_path)
     } else {
         "".into()

--- a/test/once_common_structs/models/common.rs
+++ b/test/once_common_structs/models/common.rs
@@ -1,0 +1,10 @@
+/* @generated and managed by dsync */
+#[derive(Debug, Serialize)]
+pub struct PaginationResult<T> {
+    pub items: Vec<T>,
+    pub total_items: i64,
+    /// 0-based index
+    pub page: i64,
+    pub page_size: i64,
+    pub num_pages: i64,
+}

--- a/test/once_common_structs/models/mod.rs
+++ b/test/once_common_structs/models/mod.rs
@@ -1,0 +1,3 @@
+pub mod common;
+pub mod table1;
+pub mod table2;

--- a/test/once_common_structs/models/table1/generated.rs
+++ b/test/once_common_structs/models/table1/generated.rs
@@ -1,0 +1,59 @@
+/* @generated and managed by dsync */
+
+use crate::diesel::*;
+use crate::schema::*;
+use diesel::QueryResult;
+use crate::models::common::*;
+use serde::{Deserialize, Serialize};
+
+
+type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[diesel(table_name=table1, primary_key(id))]
+pub struct Table1 {
+    pub id: crate::schema::sql_types::Int,
+}
+
+
+
+
+impl Table1 {
+
+    pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
+        use crate::schema::table1::dsl::*;
+
+        insert_into(table1).default_values().get_result::<Self>(db)
+    }
+
+    pub fn read(db: &mut ConnectionType, param_id: crate::schema::sql_types::Int) -> QueryResult<Self> {
+        use crate::schema::table1::dsl::*;
+
+        table1.filter(id.eq(param_id)).first::<Self>(db)
+    }
+
+    /// Paginates through the table where page is a 0-based index (i.e. page 0 is the first page)
+    pub fn paginate(db: &mut ConnectionType, page: i64, page_size: i64) -> QueryResult<PaginationResult<Self>> {
+        use crate::schema::table1::dsl::*;
+
+        let page_size = if page_size < 1 { 1 } else { page_size };
+        let total_items = table1.count().get_result(db)?;
+        let items = table1.limit(page_size).offset(page * page_size).load::<Self>(db)?;
+
+        Ok(PaginationResult {
+            items,
+            total_items,
+            page,
+            page_size,
+            /* ceiling division of integers */
+            num_pages: total_items / page_size + i64::from(total_items % page_size != 0)
+        })
+    }
+
+    pub fn delete(db: &mut ConnectionType, param_id: crate::schema::sql_types::Int) -> QueryResult<usize> {
+        use crate::schema::table1::dsl::*;
+
+        diesel::delete(table1.filter(id.eq(param_id))).execute(db)
+    }
+
+}

--- a/test/once_common_structs/models/table1/mod.rs
+++ b/test/once_common_structs/models/table1/mod.rs
@@ -1,0 +1,2 @@
+pub mod generated;
+pub use generated::*;

--- a/test/once_common_structs/models/table2/generated.rs
+++ b/test/once_common_structs/models/table2/generated.rs
@@ -1,0 +1,59 @@
+/* @generated and managed by dsync */
+
+use crate::diesel::*;
+use crate::schema::*;
+use diesel::QueryResult;
+use crate::models::common::*;
+use serde::{Deserialize, Serialize};
+
+
+type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
+
+#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[diesel(table_name=table2, primary_key(id))]
+pub struct Table2 {
+    pub id: crate::schema::sql_types::Int,
+}
+
+
+
+
+impl Table2 {
+
+    pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
+        use crate::schema::table2::dsl::*;
+
+        insert_into(table2).default_values().get_result::<Self>(db)
+    }
+
+    pub fn read(db: &mut ConnectionType, param_id: crate::schema::sql_types::Int) -> QueryResult<Self> {
+        use crate::schema::table2::dsl::*;
+
+        table2.filter(id.eq(param_id)).first::<Self>(db)
+    }
+
+    /// Paginates through the table where page is a 0-based index (i.e. page 0 is the first page)
+    pub fn paginate(db: &mut ConnectionType, page: i64, page_size: i64) -> QueryResult<PaginationResult<Self>> {
+        use crate::schema::table2::dsl::*;
+
+        let page_size = if page_size < 1 { 1 } else { page_size };
+        let total_items = table2.count().get_result(db)?;
+        let items = table2.limit(page_size).offset(page * page_size).load::<Self>(db)?;
+
+        Ok(PaginationResult {
+            items,
+            total_items,
+            page,
+            page_size,
+            /* ceiling division of integers */
+            num_pages: total_items / page_size + i64::from(total_items % page_size != 0)
+        })
+    }
+
+    pub fn delete(db: &mut ConnectionType, param_id: crate::schema::sql_types::Int) -> QueryResult<usize> {
+        use crate::schema::table2::dsl::*;
+
+        diesel::delete(table2.filter(id.eq(param_id))).execute(db)
+    }
+
+}

--- a/test/once_common_structs/models/table2/mod.rs
+++ b/test/once_common_structs/models/table2/mod.rs
@@ -1,0 +1,2 @@
+pub mod generated;
+pub use generated::*;

--- a/test/once_common_structs/schema.rs
+++ b/test/once_common_structs/schema.rs
@@ -1,0 +1,11 @@
+diesel::table! {
+    table1 (id) {
+        id -> Int,
+    }
+}
+
+diesel::table! {
+    table2 (id) {
+        id -> Int,
+    }
+}

--- a/test/once_common_structs/test.sh
+++ b/test/once_common_structs/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+cd $SCRIPT_DIR
+
+cargo run -- -i schema.rs -o models -g id -g created_at -g updated_at -c "diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>" --once-common-structs

--- a/test/once_common_structs_once_connection_type/models/common.rs
+++ b/test/once_common_structs_once_connection_type/models/common.rs
@@ -1,0 +1,12 @@
+/* @generated and managed by dsync */
+#[derive(Debug, Serialize)]
+pub struct PaginationResult<T> {
+    pub items: Vec<T>,
+    pub total_items: i64,
+    /// 0-based index
+    pub page: i64,
+    pub page_size: i64,
+    pub num_pages: i64,
+}
+
+type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;

--- a/test/once_common_structs_once_connection_type/models/mod.rs
+++ b/test/once_common_structs_once_connection_type/models/mod.rs
@@ -1,0 +1,3 @@
+pub mod common;
+pub mod table1;
+pub mod table2;

--- a/test/once_common_structs_once_connection_type/models/table1/generated.rs
+++ b/test/once_common_structs_once_connection_type/models/table1/generated.rs
@@ -1,0 +1,56 @@
+/* @generated and managed by dsync */
+
+use crate::diesel::*;
+use crate::schema::*;
+use diesel::QueryResult;
+use crate::models::common::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[diesel(table_name=table1, primary_key(id))]
+pub struct Table1 {
+    pub id: crate::schema::sql_types::Int,
+}
+
+
+
+
+impl Table1 {
+
+    pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
+        use crate::schema::table1::dsl::*;
+
+        insert_into(table1).default_values().get_result::<Self>(db)
+    }
+
+    pub fn read(db: &mut ConnectionType, param_id: crate::schema::sql_types::Int) -> QueryResult<Self> {
+        use crate::schema::table1::dsl::*;
+
+        table1.filter(id.eq(param_id)).first::<Self>(db)
+    }
+
+    /// Paginates through the table where page is a 0-based index (i.e. page 0 is the first page)
+    pub fn paginate(db: &mut ConnectionType, page: i64, page_size: i64) -> QueryResult<PaginationResult<Self>> {
+        use crate::schema::table1::dsl::*;
+
+        let page_size = if page_size < 1 { 1 } else { page_size };
+        let total_items = table1.count().get_result(db)?;
+        let items = table1.limit(page_size).offset(page * page_size).load::<Self>(db)?;
+
+        Ok(PaginationResult {
+            items,
+            total_items,
+            page,
+            page_size,
+            /* ceiling division of integers */
+            num_pages: total_items / page_size + i64::from(total_items % page_size != 0)
+        })
+    }
+
+    pub fn delete(db: &mut ConnectionType, param_id: crate::schema::sql_types::Int) -> QueryResult<usize> {
+        use crate::schema::table1::dsl::*;
+
+        diesel::delete(table1.filter(id.eq(param_id))).execute(db)
+    }
+
+}

--- a/test/once_common_structs_once_connection_type/models/table1/mod.rs
+++ b/test/once_common_structs_once_connection_type/models/table1/mod.rs
@@ -1,0 +1,2 @@
+pub mod generated;
+pub use generated::*;

--- a/test/once_common_structs_once_connection_type/models/table2/generated.rs
+++ b/test/once_common_structs_once_connection_type/models/table2/generated.rs
@@ -1,0 +1,56 @@
+/* @generated and managed by dsync */
+
+use crate::diesel::*;
+use crate::schema::*;
+use diesel::QueryResult;
+use crate::models::common::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[diesel(table_name=table2, primary_key(id))]
+pub struct Table2 {
+    pub id: crate::schema::sql_types::Int,
+}
+
+
+
+
+impl Table2 {
+
+    pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
+        use crate::schema::table2::dsl::*;
+
+        insert_into(table2).default_values().get_result::<Self>(db)
+    }
+
+    pub fn read(db: &mut ConnectionType, param_id: crate::schema::sql_types::Int) -> QueryResult<Self> {
+        use crate::schema::table2::dsl::*;
+
+        table2.filter(id.eq(param_id)).first::<Self>(db)
+    }
+
+    /// Paginates through the table where page is a 0-based index (i.e. page 0 is the first page)
+    pub fn paginate(db: &mut ConnectionType, page: i64, page_size: i64) -> QueryResult<PaginationResult<Self>> {
+        use crate::schema::table2::dsl::*;
+
+        let page_size = if page_size < 1 { 1 } else { page_size };
+        let total_items = table2.count().get_result(db)?;
+        let items = table2.limit(page_size).offset(page * page_size).load::<Self>(db)?;
+
+        Ok(PaginationResult {
+            items,
+            total_items,
+            page,
+            page_size,
+            /* ceiling division of integers */
+            num_pages: total_items / page_size + i64::from(total_items % page_size != 0)
+        })
+    }
+
+    pub fn delete(db: &mut ConnectionType, param_id: crate::schema::sql_types::Int) -> QueryResult<usize> {
+        use crate::schema::table2::dsl::*;
+
+        diesel::delete(table2.filter(id.eq(param_id))).execute(db)
+    }
+
+}

--- a/test/once_common_structs_once_connection_type/models/table2/mod.rs
+++ b/test/once_common_structs_once_connection_type/models/table2/mod.rs
@@ -1,0 +1,2 @@
+pub mod generated;
+pub use generated::*;

--- a/test/once_common_structs_once_connection_type/schema.rs
+++ b/test/once_common_structs_once_connection_type/schema.rs
@@ -1,0 +1,11 @@
+diesel::table! {
+    table1 (id) {
+        id -> Int,
+    }
+}
+
+diesel::table! {
+    table2 (id) {
+        id -> Int,
+    }
+}

--- a/test/once_common_structs_once_connection_type/test.sh
+++ b/test/once_common_structs_once_connection_type/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+cd $SCRIPT_DIR
+
+cargo run -- -i schema.rs -o models -g id -g created_at -g updated_at -c "diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>" --once-common-structs --once-connection-type

--- a/test/once_common_structs_once_connection_type_single_file/models/common.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/common.rs
@@ -1,0 +1,12 @@
+/* @generated and managed by dsync */
+#[derive(Debug, Serialize)]
+pub struct PaginationResult<T> {
+    pub items: Vec<T>,
+    pub total_items: i64,
+    /// 0-based index
+    pub page: i64,
+    pub page_size: i64,
+    pub num_pages: i64,
+}
+
+type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;

--- a/test/once_common_structs_once_connection_type_single_file/models/mod.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/mod.rs
@@ -1,0 +1,3 @@
+pub mod common;
+pub mod table1;
+pub mod table2;

--- a/test/once_common_structs_once_connection_type_single_file/models/table1.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/table1.rs
@@ -1,0 +1,56 @@
+/* @generated and managed by dsync */
+
+use crate::diesel::*;
+use crate::schema::*;
+use diesel::QueryResult;
+use crate::models::common::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[diesel(table_name=table1, primary_key(id))]
+pub struct Table1 {
+    pub id: crate::schema::sql_types::Int,
+}
+
+
+
+
+impl Table1 {
+
+    pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
+        use crate::schema::table1::dsl::*;
+
+        insert_into(table1).default_values().get_result::<Self>(db)
+    }
+
+    pub fn read(db: &mut ConnectionType, param_id: crate::schema::sql_types::Int) -> QueryResult<Self> {
+        use crate::schema::table1::dsl::*;
+
+        table1.filter(id.eq(param_id)).first::<Self>(db)
+    }
+
+    /// Paginates through the table where page is a 0-based index (i.e. page 0 is the first page)
+    pub fn paginate(db: &mut ConnectionType, page: i64, page_size: i64) -> QueryResult<PaginationResult<Self>> {
+        use crate::schema::table1::dsl::*;
+
+        let page_size = if page_size < 1 { 1 } else { page_size };
+        let total_items = table1.count().get_result(db)?;
+        let items = table1.limit(page_size).offset(page * page_size).load::<Self>(db)?;
+
+        Ok(PaginationResult {
+            items,
+            total_items,
+            page,
+            page_size,
+            /* ceiling division of integers */
+            num_pages: total_items / page_size + i64::from(total_items % page_size != 0)
+        })
+    }
+
+    pub fn delete(db: &mut ConnectionType, param_id: crate::schema::sql_types::Int) -> QueryResult<usize> {
+        use crate::schema::table1::dsl::*;
+
+        diesel::delete(table1.filter(id.eq(param_id))).execute(db)
+    }
+
+}

--- a/test/once_common_structs_once_connection_type_single_file/models/table2.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/table2.rs
@@ -1,0 +1,56 @@
+/* @generated and managed by dsync */
+
+use crate::diesel::*;
+use crate::schema::*;
+use diesel::QueryResult;
+use crate::models::common::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[diesel(table_name=table2, primary_key(id))]
+pub struct Table2 {
+    pub id: crate::schema::sql_types::Int,
+}
+
+
+
+
+impl Table2 {
+
+    pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
+        use crate::schema::table2::dsl::*;
+
+        insert_into(table2).default_values().get_result::<Self>(db)
+    }
+
+    pub fn read(db: &mut ConnectionType, param_id: crate::schema::sql_types::Int) -> QueryResult<Self> {
+        use crate::schema::table2::dsl::*;
+
+        table2.filter(id.eq(param_id)).first::<Self>(db)
+    }
+
+    /// Paginates through the table where page is a 0-based index (i.e. page 0 is the first page)
+    pub fn paginate(db: &mut ConnectionType, page: i64, page_size: i64) -> QueryResult<PaginationResult<Self>> {
+        use crate::schema::table2::dsl::*;
+
+        let page_size = if page_size < 1 { 1 } else { page_size };
+        let total_items = table2.count().get_result(db)?;
+        let items = table2.limit(page_size).offset(page * page_size).load::<Self>(db)?;
+
+        Ok(PaginationResult {
+            items,
+            total_items,
+            page,
+            page_size,
+            /* ceiling division of integers */
+            num_pages: total_items / page_size + i64::from(total_items % page_size != 0)
+        })
+    }
+
+    pub fn delete(db: &mut ConnectionType, param_id: crate::schema::sql_types::Int) -> QueryResult<usize> {
+        use crate::schema::table2::dsl::*;
+
+        diesel::delete(table2.filter(id.eq(param_id))).execute(db)
+    }
+
+}

--- a/test/once_common_structs_once_connection_type_single_file/schema.rs
+++ b/test/once_common_structs_once_connection_type_single_file/schema.rs
@@ -1,0 +1,11 @@
+diesel::table! {
+    table1 (id) {
+        id -> Int,
+    }
+}
+
+diesel::table! {
+    table2 (id) {
+        id -> Int,
+    }
+}

--- a/test/once_common_structs_once_connection_type_single_file/test.sh
+++ b/test/once_common_structs_once_connection_type_single_file/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+cd $SCRIPT_DIR
+
+cargo run -- -i schema.rs -o models -g id -g created_at -g updated_at -c "diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>" --once-common-structs --once-connection-type --single-model-file

--- a/test/once_connection_type/models/common.rs
+++ b/test/once_connection_type/models/common.rs
@@ -1,0 +1,2 @@
+/* @generated and managed by dsync */
+type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;

--- a/test/once_connection_type/models/mod.rs
+++ b/test/once_connection_type/models/mod.rs
@@ -1,0 +1,3 @@
+pub mod common;
+pub mod table1;
+pub mod table2;

--- a/test/once_connection_type/models/table1/generated.rs
+++ b/test/once_connection_type/models/table1/generated.rs
@@ -1,0 +1,66 @@
+/* @generated and managed by dsync */
+
+use crate::diesel::*;
+use crate::schema::*;
+use diesel::QueryResult;
+use crate::models::common::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[diesel(table_name=table1, primary_key(id))]
+pub struct Table1 {
+    pub id: crate::schema::sql_types::Int,
+}
+
+
+
+
+#[derive(Debug, Serialize)]
+pub struct PaginationResult<T> {
+    pub items: Vec<T>,
+    pub total_items: i64,
+    /// 0-based index
+    pub page: i64,
+    pub page_size: i64,
+    pub num_pages: i64,
+}
+
+impl Table1 {
+
+    pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
+        use crate::schema::table1::dsl::*;
+
+        insert_into(table1).default_values().get_result::<Self>(db)
+    }
+
+    pub fn read(db: &mut ConnectionType, param_id: crate::schema::sql_types::Int) -> QueryResult<Self> {
+        use crate::schema::table1::dsl::*;
+
+        table1.filter(id.eq(param_id)).first::<Self>(db)
+    }
+
+    /// Paginates through the table where page is a 0-based index (i.e. page 0 is the first page)
+    pub fn paginate(db: &mut ConnectionType, page: i64, page_size: i64) -> QueryResult<PaginationResult<Self>> {
+        use crate::schema::table1::dsl::*;
+
+        let page_size = if page_size < 1 { 1 } else { page_size };
+        let total_items = table1.count().get_result(db)?;
+        let items = table1.limit(page_size).offset(page * page_size).load::<Self>(db)?;
+
+        Ok(PaginationResult {
+            items,
+            total_items,
+            page,
+            page_size,
+            /* ceiling division of integers */
+            num_pages: total_items / page_size + i64::from(total_items % page_size != 0)
+        })
+    }
+
+    pub fn delete(db: &mut ConnectionType, param_id: crate::schema::sql_types::Int) -> QueryResult<usize> {
+        use crate::schema::table1::dsl::*;
+
+        diesel::delete(table1.filter(id.eq(param_id))).execute(db)
+    }
+
+}

--- a/test/once_connection_type/models/table1/mod.rs
+++ b/test/once_connection_type/models/table1/mod.rs
@@ -1,0 +1,2 @@
+pub mod generated;
+pub use generated::*;

--- a/test/once_connection_type/models/table2/generated.rs
+++ b/test/once_connection_type/models/table2/generated.rs
@@ -1,0 +1,66 @@
+/* @generated and managed by dsync */
+
+use crate::diesel::*;
+use crate::schema::*;
+use diesel::QueryResult;
+use crate::models::common::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[diesel(table_name=table2, primary_key(id))]
+pub struct Table2 {
+    pub id: crate::schema::sql_types::Int,
+}
+
+
+
+
+#[derive(Debug, Serialize)]
+pub struct PaginationResult<T> {
+    pub items: Vec<T>,
+    pub total_items: i64,
+    /// 0-based index
+    pub page: i64,
+    pub page_size: i64,
+    pub num_pages: i64,
+}
+
+impl Table2 {
+
+    pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
+        use crate::schema::table2::dsl::*;
+
+        insert_into(table2).default_values().get_result::<Self>(db)
+    }
+
+    pub fn read(db: &mut ConnectionType, param_id: crate::schema::sql_types::Int) -> QueryResult<Self> {
+        use crate::schema::table2::dsl::*;
+
+        table2.filter(id.eq(param_id)).first::<Self>(db)
+    }
+
+    /// Paginates through the table where page is a 0-based index (i.e. page 0 is the first page)
+    pub fn paginate(db: &mut ConnectionType, page: i64, page_size: i64) -> QueryResult<PaginationResult<Self>> {
+        use crate::schema::table2::dsl::*;
+
+        let page_size = if page_size < 1 { 1 } else { page_size };
+        let total_items = table2.count().get_result(db)?;
+        let items = table2.limit(page_size).offset(page * page_size).load::<Self>(db)?;
+
+        Ok(PaginationResult {
+            items,
+            total_items,
+            page,
+            page_size,
+            /* ceiling division of integers */
+            num_pages: total_items / page_size + i64::from(total_items % page_size != 0)
+        })
+    }
+
+    pub fn delete(db: &mut ConnectionType, param_id: crate::schema::sql_types::Int) -> QueryResult<usize> {
+        use crate::schema::table2::dsl::*;
+
+        diesel::delete(table2.filter(id.eq(param_id))).execute(db)
+    }
+
+}

--- a/test/once_connection_type/models/table2/mod.rs
+++ b/test/once_connection_type/models/table2/mod.rs
@@ -1,0 +1,2 @@
+pub mod generated;
+pub use generated::*;

--- a/test/once_connection_type/schema.rs
+++ b/test/once_connection_type/schema.rs
@@ -1,0 +1,11 @@
+diesel::table! {
+    table1 (id) {
+        id -> Int,
+    }
+}
+
+diesel::table! {
+    table2 (id) {
+        id -> Int,
+    }
+}

--- a/test/once_connection_type/test.sh
+++ b/test/once_connection_type/test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+cd $SCRIPT_DIR
+
+cargo run -- -i schema.rs -o models -g id -g created_at -g updated_at -c "diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>" --once-connection-type


### PR DESCRIPTION
This PR adds options `once-common-structs` and `once-connection-type`

These options are currently NOT the default

to make them default, should they still be a option or should it be unconfigurable? also i dont think `no-once-connection-type` or `no-once-common-structs` sounds good, any suggestions?

re #56 