### PR TITLE
update `file.rs`

### DIFF
--- a/src/file.rs
+++ b/src/file.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 pub struct MarkedFile {
     /// File contents that were read / need to be written
-    pub file_contents: String,
+    file_contents: String,
     /// Path of the read / to write file
     pub path: PathBuf,
     modified: bool,
@@ -31,6 +31,10 @@ impl MarkedFile {
         })
     }
 
+    pub fn get_file_contents(&self) -> &str {
+        &self.file_contents
+    }
+
     pub fn is_modified(&self) -> bool {
         self.modified
     }
@@ -41,6 +45,14 @@ impl MarkedFile {
 
     pub fn has_mod_stmt(&self, mod_name: &str) -> bool {
         self.file_contents.contains(&format!("pub mod {mod_name};"))
+    }
+
+    pub fn change_file_contents(&mut self, new_content: String) {
+        if !self.modified && self.file_contents != new_content {
+            self.modified = true;
+        }
+
+        self.file_contents = new_content;
     }
 
     pub fn add_use_stmt(&mut self, use_name: &str) {

--- a/src/file.rs
+++ b/src/file.rs
@@ -14,12 +14,7 @@ impl MarkedFile {
     ///
     /// If the file does not exist, a empty file is created
     pub fn new(path: PathBuf) -> Result<MarkedFile> {
-        let mut modified = false;
         let file_contents = if !path.exists() {
-            // TODO: should this really be created empty, instead this should likely only be done on save
-            std::fs::write(&path, "").attach_path_err(&path)?;
-            // set modified, because a file was written
-            modified = true;
             "".to_string()
         } else {
             std::fs::read_to_string(&path).attach_path_err(&path)?
@@ -27,7 +22,7 @@ impl MarkedFile {
         Ok(MarkedFile {
             path,
             file_contents,
-            modified,
+            modified: false,
         })
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -275,7 +275,7 @@ pub fn generate_files(
         let mut table_mod_rs = MarkedFile::new(table_dir.join("mod.rs"))?;
 
         table_generated_rs.ensure_file_signature()?;
-        table_generated_rs.file_contents = table.generated_code.clone();
+        table_generated_rs.change_file_contents(table.generated_code.clone());
         table_generated_rs.write()?;
 
         file_changes.push(FileChange::from(&table_generated_rs));
@@ -340,7 +340,7 @@ pub fn generate_files(
             table_mod_rs.remove_use_stmt("generated::*");
             table_mod_rs.write()?;
 
-            if table_mod_rs.file_contents.trim().is_empty() {
+            if table_mod_rs.get_file_contents().trim().is_empty() {
                 let table_mod_rs = table_mod_rs.delete()?;
                 file_changes.push(FileChange::new(table_mod_rs, FileChangeStatus::Deleted));
             } else {


### PR DESCRIPTION
This PR updates `file.rs`(`MarkedFile`):
- dont create a empty new file on `new`, only create files on `write`
- change `file_contents` to not be public, to make `modified` tracking actually work correctly