### PR TITLE
Refactor derives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 target
+.vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - add option `create-str` to set `Create*` structs string type
 - add option `update-str` to set `Update*` structs string type
 - add option `--single-model-file` to only generate a single file instead of a directory with `mod.rs` and `generated.rs`
+- derive generation has been refactored and now only necessary derives are added to a given struct
 
 ## 0.0.16
 

--- a/test/autogenerated_all/models/todos/generated.rs
+++ b/test/autogenerated_all/models/todos/generated.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     pub id: i32,
@@ -16,7 +16,7 @@ pub struct Todos {
 }
 
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     pub created_at: Option<chrono::NaiveDateTime>,

--- a/test/autogenerated_attributes/models/todos/generated.rs
+++ b/test/autogenerated_attributes/models/todos/generated.rs
@@ -8,20 +8,20 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     pub id: i32,
     pub created_at: chrono::NaiveDateTime,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
     pub id: i32,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     pub created_at: Option<chrono::NaiveDateTime>,

--- a/test/autogenerated_primary_keys/models/todos/generated.rs
+++ b/test/autogenerated_primary_keys/models/todos/generated.rs
@@ -8,20 +8,20 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     pub id: i32,
     pub text: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
     pub text: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     pub text: Option<String>,

--- a/test/cleanup_generated_content/models/todos/generated.rs
+++ b/test/cleanup_generated_content/models/todos/generated.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     pub id: i32,
@@ -18,7 +18,7 @@ pub struct Todos {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
     pub id: i32,
@@ -26,7 +26,7 @@ pub struct CreateTodos {
     pub completed: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     pub text: Option<String>,

--- a/test/create_update_str_cow/models/todos/generated.rs
+++ b/test/create_update_str_cow/models/todos/generated.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(text))]
 pub struct Todos {
     pub text: String,
@@ -17,7 +17,7 @@ pub struct Todos {
     pub varchar_nullable: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos<'a> {
     pub text: Cow<'a, str>,
@@ -26,7 +26,7 @@ pub struct CreateTodos<'a> {
     pub varchar_nullable: Option<Cow<'a, str>>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos<'a> {
     pub text_nullable: Option<Option<Cow<'a, str>>>,

--- a/test/create_update_str_str/models/todos/generated.rs
+++ b/test/create_update_str_str/models/todos/generated.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(text))]
 pub struct Todos {
     pub text: String,
@@ -17,7 +17,7 @@ pub struct Todos {
     pub varchar_nullable: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos<'a> {
     pub text: &'a str,
@@ -26,7 +26,7 @@ pub struct CreateTodos<'a> {
     pub varchar_nullable: Option<&'a str>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos<'a> {
     pub text_nullable: Option<Option<&'a str>>,

--- a/test/custom_model_and_schema_path/models/tableA/generated.rs
+++ b/test/custom_model_and_schema_path/models/tableA/generated.rs
@@ -8,13 +8,13 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=tableA, primary_key(_id))]
 pub struct TableA {
     pub _id: i32,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=tableA)]
 pub struct CreateTableA {
     pub _id: i32,

--- a/test/custom_model_and_schema_path/models/tableB/generated.rs
+++ b/test/custom_model_and_schema_path/models/tableB/generated.rs
@@ -8,21 +8,21 @@ use crate::data::models::table_a::TableA;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Identifiable, Associations, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Associations, Identifiable)]
 #[diesel(table_name=tableB, primary_key(_id), belongs_to(TableA, foreign_key=link))]
 pub struct TableB {
     pub _id: i32,
     pub link: i32,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=tableB)]
 pub struct CreateTableB {
     pub _id: i32,
     pub link: i32,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=tableB)]
 pub struct UpdateTableB {
     pub link: Option<i32>,

--- a/test/custom_model_path/models/tableA/generated.rs
+++ b/test/custom_model_path/models/tableA/generated.rs
@@ -8,13 +8,13 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=tableA, primary_key(_id))]
 pub struct TableA {
     pub _id: i32,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=tableA)]
 pub struct CreateTableA {
     pub _id: i32,

--- a/test/custom_model_path/models/tableB/generated.rs
+++ b/test/custom_model_path/models/tableB/generated.rs
@@ -8,21 +8,21 @@ use crate::data::models::table_a::TableA;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Identifiable, Associations, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Associations, Identifiable)]
 #[diesel(table_name=tableB, primary_key(_id), belongs_to(TableA, foreign_key=link))]
 pub struct TableB {
     pub _id: i32,
     pub link: i32,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=tableB)]
 pub struct CreateTableB {
     pub _id: i32,
     pub link: i32,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=tableB)]
 pub struct UpdateTableB {
     pub link: Option<i32>,

--- a/test/manual_primary_keys/models/todos/generated.rs
+++ b/test/manual_primary_keys/models/todos/generated.rs
@@ -8,13 +8,13 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     pub id: i32,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
     pub id: i32,

--- a/test/multiple_primary_keys/models/users/generated.rs
+++ b/test/multiple_primary_keys/models/users/generated.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=users, primary_key(name,address))]
 pub struct Users {
     pub name: String,
@@ -16,7 +16,7 @@ pub struct Users {
     pub secret: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=users)]
 pub struct CreateUsers {
     pub name: String,
@@ -24,7 +24,7 @@ pub struct CreateUsers {
     pub secret: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=users)]
 pub struct UpdateUsers {
     pub secret: Option<String>,

--- a/test/once_common_structs/models/table1/generated.rs
+++ b/test/once_common_structs/models/table1/generated.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {
     pub id: crate::schema::sql_types::Int,

--- a/test/once_common_structs/models/table2/generated.rs
+++ b/test/once_common_structs/models/table2/generated.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {
     pub id: crate::schema::sql_types::Int,

--- a/test/once_common_structs_once_connection_type/models/table1/generated.rs
+++ b/test/once_common_structs_once_connection_type/models/table1/generated.rs
@@ -6,7 +6,7 @@ use diesel::QueryResult;
 use crate::models::common::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {
     pub id: crate::schema::sql_types::Int,

--- a/test/once_common_structs_once_connection_type/models/table2/generated.rs
+++ b/test/once_common_structs_once_connection_type/models/table2/generated.rs
@@ -6,7 +6,7 @@ use diesel::QueryResult;
 use crate::models::common::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {
     pub id: crate::schema::sql_types::Int,

--- a/test/once_common_structs_once_connection_type_single_file/models/table1.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/table1.rs
@@ -6,7 +6,7 @@ use diesel::QueryResult;
 use crate::models::common::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {
     pub id: crate::schema::sql_types::Int,

--- a/test/once_common_structs_once_connection_type_single_file/models/table2.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/table2.rs
@@ -6,7 +6,7 @@ use diesel::QueryResult;
 use crate::models::common::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {
     pub id: crate::schema::sql_types::Int,

--- a/test/once_connection_type/models/table1/generated.rs
+++ b/test/once_connection_type/models/table1/generated.rs
@@ -6,7 +6,7 @@ use diesel::QueryResult;
 use crate::models::common::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {
     pub id: crate::schema::sql_types::Int,

--- a/test/once_connection_type/models/table2/generated.rs
+++ b/test/once_connection_type/models/table2/generated.rs
@@ -6,7 +6,7 @@ use diesel::QueryResult;
 use crate::models::common::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {
     pub id: crate::schema::sql_types::Int,

--- a/test/simple_table/models/todos/generated.rs
+++ b/test/simple_table/models/todos/generated.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     pub id: i32,
@@ -21,7 +21,7 @@ pub struct Todos {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
     pub unsigned: u32,
@@ -31,7 +31,7 @@ pub struct CreateTodos {
     pub type_: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     pub unsigned: Option<u32>,

--- a/test/simple_table_async/models/todos/generated.rs
+++ b/test/simple_table_async/models/todos/generated.rs
@@ -9,7 +9,7 @@ use diesel_async::RunQueryDsl;
 
 type ConnectionType = diesel_async::pooled_connection::deadpool::Object<diesel_async::AsyncPgConnection>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     pub id: i32,
@@ -20,7 +20,7 @@ pub struct Todos {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
     pub unsigned: u32,
@@ -28,7 +28,7 @@ pub struct CreateTodos {
     pub completed: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     pub unsigned: Option<u32>,

--- a/test/simple_table_custom_schema_path/models/todos/generated.rs
+++ b/test/simple_table_custom_schema_path/models/todos/generated.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     pub id: i32,
@@ -19,7 +19,7 @@ pub struct Todos {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
     pub unsigned: u32,
@@ -27,7 +27,7 @@ pub struct CreateTodos {
     pub completed: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     pub unsigned: Option<u32>,

--- a/test/simple_table_no_crud/models/todos/generated.rs
+++ b/test/simple_table_no_crud/models/todos/generated.rs
@@ -4,7 +4,7 @@ use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     pub id: i32,
@@ -15,7 +15,7 @@ pub struct Todos {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
     pub unsigned: u32,
@@ -23,7 +23,7 @@ pub struct CreateTodos {
     pub completed: bool,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     pub unsigned: Option<u32>,

--- a/test/simple_table_no_serde/models/todos/generated.rs
+++ b/test/simple_table_no_serde/models/todos/generated.rs
@@ -8,7 +8,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Clone, Queryable, Insertable, AsChangeset, Selectable)]
+#[derive(Debug, Clone, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     pub id: i32,
@@ -19,7 +19,7 @@ pub struct Todos {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, Clone, Queryable, Insertable, AsChangeset)]
+#[derive(Debug, Clone, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
     pub unsigned: u32,
@@ -27,7 +27,7 @@ pub struct CreateTodos {
     pub completed: bool,
 }
 
-#[derive(Debug, Clone, Queryable, Insertable, AsChangeset, Default)]
+#[derive(Debug, Clone, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     pub unsigned: Option<u32>,

--- a/test/single_model_file/models/table1.rs
+++ b/test/single_model_file/models/table1.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {
     pub id: crate::schema::sql_types::Int,

--- a/test/single_model_file/models/table2.rs
+++ b/test/single_model_file/models/table2.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {
     pub id: crate::schema::sql_types::Int,

--- a/test/use_statements/models/fang_tasks/generated.rs
+++ b/test/use_statements/models/fang_tasks/generated.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Selectable)]
+#[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=fang_tasks, primary_key(id))]
 pub struct FangTasks {
     pub id: uuid::Uuid,
@@ -23,7 +23,7 @@ pub struct FangTasks {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset)]
+#[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=fang_tasks)]
 pub struct CreateFangTasks {
     pub id: uuid::Uuid,
@@ -38,7 +38,7 @@ pub struct CreateFangTasks {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone, Queryable, Insertable, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=fang_tasks)]
 pub struct UpdateFangTasks {
     pub metadata: Option<serde_json::Value>,


### PR DESCRIPTION
This PR refactors how the derives are generated, this should make it easier to work with. Also now only generates the necessary derives which a given StructType needs.

As a side-effect the order of derives have slightly changed

re #56 `--only-necessary-derives`