### PR TITLE
Generate doc-comments for structs, fields and functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - rename `type Connection =` to `type ConnectionType =` to lessen naming conflicts
 - add many doc-comments to fields and functions
 - list changes to files (unchanged, modified, deleted)
+- generate doc-comments for generated structs, fields and functions
 
 ## 0.0.17 (yanked)
 

--- a/src/code.rs
+++ b/src/code.rs
@@ -74,6 +74,8 @@ pub struct StructField {
     /// Name for the field
     // TODO: should this be a Ident instead of a string?
     pub name: String,
+    /// Actual table column name
+    pub column_name: String,
     /// Base Rust type, like "String" or "i32" or "u32"
     pub base_type: String,
     /// Indicate that this field is optional
@@ -105,6 +107,7 @@ impl From<&ParsedColumnMacro> for StructField {
             name,
             base_type,
             is_optional: value.is_nullable,
+            column_name: value.column_name.clone(),
         }
     }
 }
@@ -313,6 +316,10 @@ impl<'a> Struct<'a> {
                 field_type = format!("Option<{}>", field_type).into();
             }
 
+            lines.push(format!(
+                "    /// Field representing column `{column_name}`",
+                column_name = f.column_name
+            ));
             lines.push(format!(r#"    pub {field_name}: {field_type},"#));
         }
 

--- a/src/code.rs
+++ b/src/code.rs
@@ -563,13 +563,18 @@ pub fn generate_common_structs(table_options: &TableOptions<'_>) -> String {
 
     formatdoc!(
         r##"
+        /// Result of a `.paginate` function
         {tsync}#[derive({debug_derive}, {serde_derive})]
         pub struct PaginationResult<T> {{
+            /// Resulting items that are from the current page
             pub items: Vec<T>,
+            /// The count of total items there are
             pub total_items: i64,
-            /// 0-based index
+            /// Current page, 0-based index
             pub page: i64,
+            /// Size of a page
             pub page_size: i64,
+            /// Number of total possible pages, given the `page_size` and `total_items`
             pub num_pages: i64,
         }}
         "##,

--- a/src/code.rs
+++ b/src/code.rs
@@ -316,8 +316,26 @@ impl<'a> Struct<'a> {
             lines.push(format!(r#"    pub {field_name}: {field_type},"#));
         }
 
+        let doccomment = match ty {
+            StructType::Read => format!(
+                "/// Struct representing a row in table `{table_name}`",
+                table_name = table.name
+            ),
+            StructType::Update => format!(
+                "/// Update Struct for a row in table `{table_name}` for [`{read_struct}`]",
+                table_name = table.name,
+                read_struct = table.struct_name
+            ),
+            StructType::Create => format!(
+                "/// Create Struct for a row in table `{table_name}` for [`{read_struct}`]",
+                table_name = table.name,
+                read_struct = table.struct_name
+            ),
+        };
+
         let struct_code = formatdoc!(
             r#"
+            {doccomment}
             {tsync_attr}{derive_attr}
             #[diesel(table_name={table_name}{primary_key}{belongs_to})]
             pub struct {struct_name}{lifetimes} {{

--- a/test/autogenerated_all/models/todos/generated.rs
+++ b/test/autogenerated_all/models/todos/generated.rs
@@ -7,6 +7,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `todos`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
@@ -14,6 +15,7 @@ pub struct Todos {
     pub created_at: chrono::NaiveDateTime,
 }
 
+/// Update Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {

--- a/test/autogenerated_all/models/todos/generated.rs
+++ b/test/autogenerated_all/models/todos/generated.rs
@@ -36,12 +36,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Todos {
+    /// Insert a new row into `todos` with all default values
     pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).default_values().get_result::<Self>(db)
     }
 
+    /// Get a row from `todos`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
@@ -66,12 +68,14 @@ impl Todos {
         })
     }
 
+    /// Update a row in `todos`, identified by the primary key with [`UpdateTodos`]
     pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)
     }
 
+    /// Delete a row in `todos`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::todos::dsl::*;
 

--- a/test/autogenerated_all/models/todos/generated.rs
+++ b/test/autogenerated_all/models/todos/generated.rs
@@ -25,13 +25,18 @@ pub struct UpdateTodos {
     pub created_at: Option<chrono::NaiveDateTime>,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/autogenerated_all/models/todos/generated.rs
+++ b/test/autogenerated_all/models/todos/generated.rs
@@ -11,7 +11,9 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
+    /// Field representing column `id`
     pub id: i32,
+    /// Field representing column `created_at`
     pub created_at: chrono::NaiveDateTime,
 }
 
@@ -19,6 +21,7 @@ pub struct Todos {
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
+    /// Field representing column `created_at`
     pub created_at: Option<chrono::NaiveDateTime>,
 }
 

--- a/test/autogenerated_attributes/models/todos/generated.rs
+++ b/test/autogenerated_attributes/models/todos/generated.rs
@@ -11,7 +11,9 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
+    /// Field representing column `id`
     pub id: i32,
+    /// Field representing column `created_at`
     pub created_at: chrono::NaiveDateTime,
 }
 
@@ -19,6 +21,7 @@ pub struct Todos {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
+    /// Field representing column `id`
     pub id: i32,
 }
 
@@ -26,6 +29,7 @@ pub struct CreateTodos {
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
+    /// Field representing column `created_at`
     pub created_at: Option<chrono::NaiveDateTime>,
 }
 

--- a/test/autogenerated_attributes/models/todos/generated.rs
+++ b/test/autogenerated_attributes/models/todos/generated.rs
@@ -44,12 +44,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Todos {
+    /// Insert a new row into `todos` with a given [`CreateTodos`]
     pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db)
     }
 
+    /// Get a row from `todos`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
@@ -74,12 +76,14 @@ impl Todos {
         })
     }
 
+    /// Update a row in `todos`, identified by the primary key with [`UpdateTodos`]
     pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)
     }
 
+    /// Delete a row in `todos`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::todos::dsl::*;
 

--- a/test/autogenerated_attributes/models/todos/generated.rs
+++ b/test/autogenerated_attributes/models/todos/generated.rs
@@ -33,13 +33,18 @@ pub struct UpdateTodos {
     pub created_at: Option<chrono::NaiveDateTime>,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/autogenerated_attributes/models/todos/generated.rs
+++ b/test/autogenerated_attributes/models/todos/generated.rs
@@ -7,6 +7,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `todos`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
@@ -14,12 +15,14 @@ pub struct Todos {
     pub created_at: chrono::NaiveDateTime,
 }
 
+/// Create Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
     pub id: i32,
 }
 
+/// Update Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {

--- a/test/autogenerated_primary_keys/models/todos/generated.rs
+++ b/test/autogenerated_primary_keys/models/todos/generated.rs
@@ -44,12 +44,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Todos {
+    /// Insert a new row into `todos` with a given [`CreateTodos`]
     pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db)
     }
 
+    /// Get a row from `todos`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
@@ -74,12 +76,14 @@ impl Todos {
         })
     }
 
+    /// Update a row in `todos`, identified by the primary key with [`UpdateTodos`]
     pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)
     }
 
+    /// Delete a row in `todos`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::todos::dsl::*;
 

--- a/test/autogenerated_primary_keys/models/todos/generated.rs
+++ b/test/autogenerated_primary_keys/models/todos/generated.rs
@@ -33,13 +33,18 @@ pub struct UpdateTodos {
     pub text: Option<String>,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/autogenerated_primary_keys/models/todos/generated.rs
+++ b/test/autogenerated_primary_keys/models/todos/generated.rs
@@ -11,7 +11,9 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
+    /// Field representing column `id`
     pub id: i32,
+    /// Field representing column `text`
     pub text: String,
 }
 
@@ -19,6 +21,7 @@ pub struct Todos {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
+    /// Field representing column `text`
     pub text: String,
 }
 
@@ -26,6 +29,7 @@ pub struct CreateTodos {
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
+    /// Field representing column `text`
     pub text: Option<String>,
 }
 

--- a/test/autogenerated_primary_keys/models/todos/generated.rs
+++ b/test/autogenerated_primary_keys/models/todos/generated.rs
@@ -7,6 +7,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `todos`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
@@ -14,12 +15,14 @@ pub struct Todos {
     pub text: String,
 }
 
+/// Create Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
     pub text: String,
 }
 
+/// Update Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {

--- a/test/cleanup_generated_content/models/todos/generated.rs
+++ b/test/cleanup_generated_content/models/todos/generated.rs
@@ -60,12 +60,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Todos {
+    /// Insert a new row into `todos` with a given [`CreateTodos`]
     pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db)
     }
 
+    /// Get a row from `todos`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
@@ -90,12 +92,14 @@ impl Todos {
         })
     }
 
+    /// Update a row in `todos`, identified by the primary key with [`UpdateTodos`]
     pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)
     }
 
+    /// Delete a row in `todos`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::todos::dsl::*;
 

--- a/test/cleanup_generated_content/models/todos/generated.rs
+++ b/test/cleanup_generated_content/models/todos/generated.rs
@@ -49,13 +49,18 @@ pub struct UpdateTodos {
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/cleanup_generated_content/models/todos/generated.rs
+++ b/test/cleanup_generated_content/models/todos/generated.rs
@@ -7,6 +7,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `todos`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
@@ -17,6 +18,7 @@ pub struct Todos {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
+/// Create Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
@@ -25,6 +27,7 @@ pub struct CreateTodos {
     pub completed: bool,
 }
 
+/// Update Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {

--- a/test/cleanup_generated_content/models/todos/generated.rs
+++ b/test/cleanup_generated_content/models/todos/generated.rs
@@ -11,10 +11,15 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
+    /// Field representing column `id`
     pub id: i32,
+    /// Field representing column `text`
     pub text: String,
+    /// Field representing column `completed`
     pub completed: bool,
+    /// Field representing column `created_at`
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Field representing column `updated_at`
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -22,8 +27,11 @@ pub struct Todos {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
+    /// Field representing column `id`
     pub id: i32,
+    /// Field representing column `text`
     pub text: String,
+    /// Field representing column `completed`
     pub completed: bool,
 }
 
@@ -31,9 +39,13 @@ pub struct CreateTodos {
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
+    /// Field representing column `text`
     pub text: Option<String>,
+    /// Field representing column `completed`
     pub completed: Option<bool>,
+    /// Field representing column `created_at`
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Field representing column `updated_at`
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 

--- a/test/create_update_str_cow/models/todos/generated.rs
+++ b/test/create_update_str_cow/models/todos/generated.rs
@@ -7,6 +7,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `todos`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(text))]
 pub struct Todos {
@@ -16,6 +17,7 @@ pub struct Todos {
     pub varchar_nullable: Option<String>,
 }
 
+/// Create Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos<'a> {
@@ -25,6 +27,7 @@ pub struct CreateTodos<'a> {
     pub varchar_nullable: Option<Cow<'a, str>>,
 }
 
+/// Update Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos<'a> {

--- a/test/create_update_str_cow/models/todos/generated.rs
+++ b/test/create_update_str_cow/models/todos/generated.rs
@@ -11,9 +11,13 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(text))]
 pub struct Todos {
+    /// Field representing column `text`
     pub text: String,
+    /// Field representing column `text_nullable`
     pub text_nullable: Option<String>,
+    /// Field representing column `varchar`
     pub varchar: String,
+    /// Field representing column `varchar_nullable`
     pub varchar_nullable: Option<String>,
 }
 
@@ -21,9 +25,13 @@ pub struct Todos {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos<'a> {
+    /// Field representing column `text`
     pub text: Cow<'a, str>,
+    /// Field representing column `text_nullable`
     pub text_nullable: Option<Cow<'a, str>>,
+    /// Field representing column `varchar`
     pub varchar: Cow<'a, str>,
+    /// Field representing column `varchar_nullable`
     pub varchar_nullable: Option<Cow<'a, str>>,
 }
 
@@ -31,8 +39,11 @@ pub struct CreateTodos<'a> {
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos<'a> {
+    /// Field representing column `text_nullable`
     pub text_nullable: Option<Option<Cow<'a, str>>>,
+    /// Field representing column `varchar`
     pub varchar: Option<Cow<'a, str>>,
+    /// Field representing column `varchar_nullable`
     pub varchar_nullable: Option<Option<Cow<'a, str>>>,
 }
 

--- a/test/create_update_str_cow/models/todos/generated.rs
+++ b/test/create_update_str_cow/models/todos/generated.rs
@@ -47,13 +47,18 @@ pub struct UpdateTodos<'a> {
     pub varchar_nullable: Option<Option<Cow<'a, str>>>,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/create_update_str_cow/models/todos/generated.rs
+++ b/test/create_update_str_cow/models/todos/generated.rs
@@ -58,12 +58,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Todos {
+    /// Insert a new row into `todos` with a given [`CreateTodos`]
     pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db)
     }
 
+    /// Get a row from `todos`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_text: String) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
@@ -88,12 +90,14 @@ impl Todos {
         })
     }
 
+    /// Update a row in `todos`, identified by the primary key with [`UpdateTodos`]
     pub fn update(db: &mut ConnectionType, param_text: String, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         diesel::update(todos.filter(text.eq(param_text))).set(item).get_result(db)
     }
 
+    /// Delete a row in `todos`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_text: String) -> QueryResult<usize> {
         use crate::schema::todos::dsl::*;
 

--- a/test/create_update_str_str/models/todos/generated.rs
+++ b/test/create_update_str_str/models/todos/generated.rs
@@ -11,9 +11,13 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(text))]
 pub struct Todos {
+    /// Field representing column `text`
     pub text: String,
+    /// Field representing column `text_nullable`
     pub text_nullable: Option<String>,
+    /// Field representing column `varchar`
     pub varchar: String,
+    /// Field representing column `varchar_nullable`
     pub varchar_nullable: Option<String>,
 }
 
@@ -21,9 +25,13 @@ pub struct Todos {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos<'a> {
+    /// Field representing column `text`
     pub text: &'a str,
+    /// Field representing column `text_nullable`
     pub text_nullable: Option<&'a str>,
+    /// Field representing column `varchar`
     pub varchar: &'a str,
+    /// Field representing column `varchar_nullable`
     pub varchar_nullable: Option<&'a str>,
 }
 
@@ -31,8 +39,11 @@ pub struct CreateTodos<'a> {
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos<'a> {
+    /// Field representing column `text_nullable`
     pub text_nullable: Option<Option<&'a str>>,
+    /// Field representing column `varchar`
     pub varchar: Option<&'a str>,
+    /// Field representing column `varchar_nullable`
     pub varchar_nullable: Option<Option<&'a str>>,
 }
 

--- a/test/create_update_str_str/models/todos/generated.rs
+++ b/test/create_update_str_str/models/todos/generated.rs
@@ -7,6 +7,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `todos`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(text))]
 pub struct Todos {
@@ -16,6 +17,7 @@ pub struct Todos {
     pub varchar_nullable: Option<String>,
 }
 
+/// Create Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos<'a> {
@@ -25,6 +27,7 @@ pub struct CreateTodos<'a> {
     pub varchar_nullable: Option<&'a str>,
 }
 
+/// Update Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos<'a> {

--- a/test/create_update_str_str/models/todos/generated.rs
+++ b/test/create_update_str_str/models/todos/generated.rs
@@ -47,13 +47,18 @@ pub struct UpdateTodos<'a> {
     pub varchar_nullable: Option<Option<&'a str>>,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/create_update_str_str/models/todos/generated.rs
+++ b/test/create_update_str_str/models/todos/generated.rs
@@ -58,12 +58,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Todos {
+    /// Insert a new row into `todos` with a given [`CreateTodos`]
     pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db)
     }
 
+    /// Get a row from `todos`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_text: String) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
@@ -88,12 +90,14 @@ impl Todos {
         })
     }
 
+    /// Update a row in `todos`, identified by the primary key with [`UpdateTodos`]
     pub fn update(db: &mut ConnectionType, param_text: String, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         diesel::update(todos.filter(text.eq(param_text))).set(item).get_result(db)
     }
 
+    /// Delete a row in `todos`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_text: String) -> QueryResult<usize> {
         use crate::schema::todos::dsl::*;
 

--- a/test/custom_model_and_schema_path/models/tableA/generated.rs
+++ b/test/custom_model_and_schema_path/models/tableA/generated.rs
@@ -11,6 +11,7 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=tableA, primary_key(_id))]
 pub struct TableA {
+    /// Field representing column `_id`
     pub _id: i32,
 }
 
@@ -18,6 +19,7 @@ pub struct TableA {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=tableA)]
 pub struct CreateTableA {
+    /// Field representing column `_id`
     pub _id: i32,
 }
 

--- a/test/custom_model_and_schema_path/models/tableA/generated.rs
+++ b/test/custom_model_and_schema_path/models/tableA/generated.rs
@@ -34,12 +34,14 @@ pub struct PaginationResult<T> {
 }
 
 impl TableA {
+    /// Insert a new row into `tableA` with a given [`CreateTableA`]
     pub fn create(db: &mut ConnectionType, item: &CreateTableA) -> QueryResult<Self> {
         use crate::data::schema::tableA::dsl::*;
 
         insert_into(tableA).values(item).get_result::<Self>(db)
     }
 
+    /// Get a row from `tableA`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param__id: i32) -> QueryResult<Self> {
         use crate::data::schema::tableA::dsl::*;
 
@@ -64,6 +66,7 @@ impl TableA {
         })
     }
 
+    /// Delete a row in `tableA`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param__id: i32) -> QueryResult<usize> {
         use crate::data::schema::tableA::dsl::*;
 

--- a/test/custom_model_and_schema_path/models/tableA/generated.rs
+++ b/test/custom_model_and_schema_path/models/tableA/generated.rs
@@ -7,12 +7,14 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `tableA`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=tableA, primary_key(_id))]
 pub struct TableA {
     pub _id: i32,
 }
 
+/// Create Struct for a row in table `tableA` for [`TableA`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=tableA)]
 pub struct CreateTableA {

--- a/test/custom_model_and_schema_path/models/tableA/generated.rs
+++ b/test/custom_model_and_schema_path/models/tableA/generated.rs
@@ -23,13 +23,18 @@ pub struct CreateTableA {
     pub _id: i32,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/custom_model_and_schema_path/models/tableB/generated.rs
+++ b/test/custom_model_and_schema_path/models/tableB/generated.rs
@@ -47,12 +47,14 @@ pub struct PaginationResult<T> {
 }
 
 impl TableB {
+    /// Insert a new row into `tableB` with a given [`CreateTableB`]
     pub fn create(db: &mut ConnectionType, item: &CreateTableB) -> QueryResult<Self> {
         use crate::data::schema::tableB::dsl::*;
 
         insert_into(tableB).values(item).get_result::<Self>(db)
     }
 
+    /// Get a row from `tableB`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param__id: i32) -> QueryResult<Self> {
         use crate::data::schema::tableB::dsl::*;
 
@@ -77,12 +79,14 @@ impl TableB {
         })
     }
 
+    /// Update a row in `tableB`, identified by the primary key with [`UpdateTableB`]
     pub fn update(db: &mut ConnectionType, param__id: i32, item: &UpdateTableB) -> QueryResult<Self> {
         use crate::data::schema::tableB::dsl::*;
 
         diesel::update(tableB.filter(_id.eq(param__id))).set(item).get_result(db)
     }
 
+    /// Delete a row in `tableB`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param__id: i32) -> QueryResult<usize> {
         use crate::data::schema::tableB::dsl::*;
 

--- a/test/custom_model_and_schema_path/models/tableB/generated.rs
+++ b/test/custom_model_and_schema_path/models/tableB/generated.rs
@@ -36,13 +36,18 @@ pub struct UpdateTableB {
     pub link: Option<i32>,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/custom_model_and_schema_path/models/tableB/generated.rs
+++ b/test/custom_model_and_schema_path/models/tableB/generated.rs
@@ -8,6 +8,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `tableB`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Associations, Identifiable)]
 #[diesel(table_name=tableB, primary_key(_id), belongs_to(TableA, foreign_key=link))]
 pub struct TableB {
@@ -15,6 +16,7 @@ pub struct TableB {
     pub link: i32,
 }
 
+/// Create Struct for a row in table `tableB` for [`TableB`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=tableB)]
 pub struct CreateTableB {
@@ -22,6 +24,7 @@ pub struct CreateTableB {
     pub link: i32,
 }
 
+/// Update Struct for a row in table `tableB` for [`TableB`]
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=tableB)]
 pub struct UpdateTableB {

--- a/test/custom_model_and_schema_path/models/tableB/generated.rs
+++ b/test/custom_model_and_schema_path/models/tableB/generated.rs
@@ -12,7 +12,9 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Associations, Identifiable)]
 #[diesel(table_name=tableB, primary_key(_id), belongs_to(TableA, foreign_key=link))]
 pub struct TableB {
+    /// Field representing column `_id`
     pub _id: i32,
+    /// Field representing column `link`
     pub link: i32,
 }
 
@@ -20,7 +22,9 @@ pub struct TableB {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=tableB)]
 pub struct CreateTableB {
+    /// Field representing column `_id`
     pub _id: i32,
+    /// Field representing column `link`
     pub link: i32,
 }
 
@@ -28,6 +32,7 @@ pub struct CreateTableB {
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=tableB)]
 pub struct UpdateTableB {
+    /// Field representing column `link`
     pub link: Option<i32>,
 }
 

--- a/test/custom_model_path/models/tableA/generated.rs
+++ b/test/custom_model_path/models/tableA/generated.rs
@@ -11,6 +11,7 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=tableA, primary_key(_id))]
 pub struct TableA {
+    /// Field representing column `_id`
     pub _id: i32,
 }
 
@@ -18,6 +19,7 @@ pub struct TableA {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=tableA)]
 pub struct CreateTableA {
+    /// Field representing column `_id`
     pub _id: i32,
 }
 

--- a/test/custom_model_path/models/tableA/generated.rs
+++ b/test/custom_model_path/models/tableA/generated.rs
@@ -7,12 +7,14 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `tableA`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=tableA, primary_key(_id))]
 pub struct TableA {
     pub _id: i32,
 }
 
+/// Create Struct for a row in table `tableA` for [`TableA`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=tableA)]
 pub struct CreateTableA {

--- a/test/custom_model_path/models/tableA/generated.rs
+++ b/test/custom_model_path/models/tableA/generated.rs
@@ -34,12 +34,14 @@ pub struct PaginationResult<T> {
 }
 
 impl TableA {
+    /// Insert a new row into `tableA` with a given [`CreateTableA`]
     pub fn create(db: &mut ConnectionType, item: &CreateTableA) -> QueryResult<Self> {
         use crate::schema::tableA::dsl::*;
 
         insert_into(tableA).values(item).get_result::<Self>(db)
     }
 
+    /// Get a row from `tableA`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param__id: i32) -> QueryResult<Self> {
         use crate::schema::tableA::dsl::*;
 
@@ -64,6 +66,7 @@ impl TableA {
         })
     }
 
+    /// Delete a row in `tableA`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param__id: i32) -> QueryResult<usize> {
         use crate::schema::tableA::dsl::*;
 

--- a/test/custom_model_path/models/tableA/generated.rs
+++ b/test/custom_model_path/models/tableA/generated.rs
@@ -23,13 +23,18 @@ pub struct CreateTableA {
     pub _id: i32,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/custom_model_path/models/tableB/generated.rs
+++ b/test/custom_model_path/models/tableB/generated.rs
@@ -47,12 +47,14 @@ pub struct PaginationResult<T> {
 }
 
 impl TableB {
+    /// Insert a new row into `tableB` with a given [`CreateTableB`]
     pub fn create(db: &mut ConnectionType, item: &CreateTableB) -> QueryResult<Self> {
         use crate::schema::tableB::dsl::*;
 
         insert_into(tableB).values(item).get_result::<Self>(db)
     }
 
+    /// Get a row from `tableB`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param__id: i32) -> QueryResult<Self> {
         use crate::schema::tableB::dsl::*;
 
@@ -77,12 +79,14 @@ impl TableB {
         })
     }
 
+    /// Update a row in `tableB`, identified by the primary key with [`UpdateTableB`]
     pub fn update(db: &mut ConnectionType, param__id: i32, item: &UpdateTableB) -> QueryResult<Self> {
         use crate::schema::tableB::dsl::*;
 
         diesel::update(tableB.filter(_id.eq(param__id))).set(item).get_result(db)
     }
 
+    /// Delete a row in `tableB`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param__id: i32) -> QueryResult<usize> {
         use crate::schema::tableB::dsl::*;
 

--- a/test/custom_model_path/models/tableB/generated.rs
+++ b/test/custom_model_path/models/tableB/generated.rs
@@ -36,13 +36,18 @@ pub struct UpdateTableB {
     pub link: Option<i32>,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/custom_model_path/models/tableB/generated.rs
+++ b/test/custom_model_path/models/tableB/generated.rs
@@ -8,6 +8,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `tableB`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Associations, Identifiable)]
 #[diesel(table_name=tableB, primary_key(_id), belongs_to(TableA, foreign_key=link))]
 pub struct TableB {
@@ -15,6 +16,7 @@ pub struct TableB {
     pub link: i32,
 }
 
+/// Create Struct for a row in table `tableB` for [`TableB`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=tableB)]
 pub struct CreateTableB {
@@ -22,6 +24,7 @@ pub struct CreateTableB {
     pub link: i32,
 }
 
+/// Update Struct for a row in table `tableB` for [`TableB`]
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=tableB)]
 pub struct UpdateTableB {

--- a/test/custom_model_path/models/tableB/generated.rs
+++ b/test/custom_model_path/models/tableB/generated.rs
@@ -12,7 +12,9 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable, Associations, Identifiable)]
 #[diesel(table_name=tableB, primary_key(_id), belongs_to(TableA, foreign_key=link))]
 pub struct TableB {
+    /// Field representing column `_id`
     pub _id: i32,
+    /// Field representing column `link`
     pub link: i32,
 }
 
@@ -20,7 +22,9 @@ pub struct TableB {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=tableB)]
 pub struct CreateTableB {
+    /// Field representing column `_id`
     pub _id: i32,
+    /// Field representing column `link`
     pub link: i32,
 }
 
@@ -28,6 +32,7 @@ pub struct CreateTableB {
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=tableB)]
 pub struct UpdateTableB {
+    /// Field representing column `link`
     pub link: Option<i32>,
 }
 

--- a/test/manual_primary_keys/models/todos/generated.rs
+++ b/test/manual_primary_keys/models/todos/generated.rs
@@ -34,12 +34,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Todos {
+    /// Insert a new row into `todos` with a given [`CreateTodos`]
     pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db)
     }
 
+    /// Get a row from `todos`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
@@ -64,6 +66,7 @@ impl Todos {
         })
     }
 
+    /// Delete a row in `todos`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::todos::dsl::*;
 

--- a/test/manual_primary_keys/models/todos/generated.rs
+++ b/test/manual_primary_keys/models/todos/generated.rs
@@ -7,12 +7,14 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `todos`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     pub id: i32,
 }
 
+/// Create Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {

--- a/test/manual_primary_keys/models/todos/generated.rs
+++ b/test/manual_primary_keys/models/todos/generated.rs
@@ -23,13 +23,18 @@ pub struct CreateTodos {
     pub id: i32,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/manual_primary_keys/models/todos/generated.rs
+++ b/test/manual_primary_keys/models/todos/generated.rs
@@ -11,6 +11,7 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
+    /// Field representing column `id`
     pub id: i32,
 }
 
@@ -18,6 +19,7 @@ pub struct Todos {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
+    /// Field representing column `id`
     pub id: i32,
 }
 

--- a/test/multiple_primary_keys/models/users/generated.rs
+++ b/test/multiple_primary_keys/models/users/generated.rs
@@ -11,8 +11,11 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=users, primary_key(name,address))]
 pub struct Users {
+    /// Field representing column `name`
     pub name: String,
+    /// Field representing column `address`
     pub address: String,
+    /// Field representing column `secret`
     pub secret: String,
 }
 
@@ -20,8 +23,11 @@ pub struct Users {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=users)]
 pub struct CreateUsers {
+    /// Field representing column `name`
     pub name: String,
+    /// Field representing column `address`
     pub address: String,
+    /// Field representing column `secret`
     pub secret: String,
 }
 
@@ -29,6 +35,7 @@ pub struct CreateUsers {
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=users)]
 pub struct UpdateUsers {
+    /// Field representing column `secret`
     pub secret: Option<String>,
 }
 

--- a/test/multiple_primary_keys/models/users/generated.rs
+++ b/test/multiple_primary_keys/models/users/generated.rs
@@ -7,6 +7,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `users`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=users, primary_key(name,address))]
 pub struct Users {
@@ -15,6 +16,7 @@ pub struct Users {
     pub secret: String,
 }
 
+/// Create Struct for a row in table `users` for [`Users`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=users)]
 pub struct CreateUsers {
@@ -23,6 +25,7 @@ pub struct CreateUsers {
     pub secret: String,
 }
 
+/// Update Struct for a row in table `users` for [`Users`]
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=users)]
 pub struct UpdateUsers {

--- a/test/multiple_primary_keys/models/users/generated.rs
+++ b/test/multiple_primary_keys/models/users/generated.rs
@@ -39,13 +39,18 @@ pub struct UpdateUsers {
     pub secret: Option<String>,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/multiple_primary_keys/models/users/generated.rs
+++ b/test/multiple_primary_keys/models/users/generated.rs
@@ -50,12 +50,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Users {
+    /// Insert a new row into `users` with a given [`CreateUsers`]
     pub fn create(db: &mut ConnectionType, item: &CreateUsers) -> QueryResult<Self> {
         use crate::schema::users::dsl::*;
 
         insert_into(users).values(item).get_result::<Self>(db)
     }
 
+    /// Get a row from `users`, identified by the primary keys
     pub fn read(db: &mut ConnectionType, param_name: String, param_address: String) -> QueryResult<Self> {
         use crate::schema::users::dsl::*;
 
@@ -80,12 +82,14 @@ impl Users {
         })
     }
 
+    /// Update a row in `users`, identified by the primary keys with [`UpdateUsers`]
     pub fn update(db: &mut ConnectionType, param_name: String, param_address: String, item: &UpdateUsers) -> QueryResult<Self> {
         use crate::schema::users::dsl::*;
 
         diesel::update(users.filter(name.eq(param_name)).filter(address.eq(param_address))).set(item).get_result(db)
     }
 
+    /// Delete a row in `users`, identified by the primary keys
     pub fn delete(db: &mut ConnectionType, param_name: String, param_address: String) -> QueryResult<usize> {
         use crate::schema::users::dsl::*;
 

--- a/test/once_common_structs/models/common.rs
+++ b/test/once_common_structs/models/common.rs
@@ -1,10 +1,15 @@
 /* @generated and managed by dsync */
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }

--- a/test/once_common_structs/models/table1/generated.rs
+++ b/test/once_common_structs/models/table1/generated.rs
@@ -8,6 +8,7 @@ use crate::models::common::*;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `table1`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {

--- a/test/once_common_structs/models/table1/generated.rs
+++ b/test/once_common_structs/models/table1/generated.rs
@@ -17,12 +17,14 @@ pub struct Table1 {
 }
 
 impl Table1 {
+    /// Insert a new row into `table1` with all default values
     pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
         use crate::schema::table1::dsl::*;
 
         insert_into(table1).default_values().get_result::<Self>(db)
     }
 
+    /// Get a row from `table1`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::table1::dsl::*;
 
@@ -47,6 +49,7 @@ impl Table1 {
         })
     }
 
+    /// Delete a row in `table1`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::table1::dsl::*;
 

--- a/test/once_common_structs/models/table1/generated.rs
+++ b/test/once_common_structs/models/table1/generated.rs
@@ -12,6 +12,7 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {
+    /// Field representing column `id`
     pub id: i32,
 }
 

--- a/test/once_common_structs/models/table2/generated.rs
+++ b/test/once_common_structs/models/table2/generated.rs
@@ -12,6 +12,7 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {
+    /// Field representing column `id`
     pub id: i32,
 }
 

--- a/test/once_common_structs/models/table2/generated.rs
+++ b/test/once_common_structs/models/table2/generated.rs
@@ -8,6 +8,7 @@ use crate::models::common::*;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `table2`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {

--- a/test/once_common_structs/models/table2/generated.rs
+++ b/test/once_common_structs/models/table2/generated.rs
@@ -17,12 +17,14 @@ pub struct Table2 {
 }
 
 impl Table2 {
+    /// Insert a new row into `table2` with all default values
     pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
         use crate::schema::table2::dsl::*;
 
         insert_into(table2).default_values().get_result::<Self>(db)
     }
 
+    /// Get a row from `table2`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::table2::dsl::*;
 
@@ -47,6 +49,7 @@ impl Table2 {
         })
     }
 
+    /// Delete a row in `table2`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::table2::dsl::*;
 

--- a/test/once_common_structs_once_connection_type/models/common.rs
+++ b/test/once_common_structs_once_connection_type/models/common.rs
@@ -1,11 +1,16 @@
 /* @generated and managed by dsync */
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/once_common_structs_once_connection_type/models/table1/generated.rs
+++ b/test/once_common_structs_once_connection_type/models/table1/generated.rs
@@ -15,12 +15,14 @@ pub struct Table1 {
 }
 
 impl Table1 {
+    /// Insert a new row into `table1` with all default values
     pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
         use crate::schema::table1::dsl::*;
 
         insert_into(table1).default_values().get_result::<Self>(db)
     }
 
+    /// Get a row from `table1`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::table1::dsl::*;
 
@@ -45,6 +47,7 @@ impl Table1 {
         })
     }
 
+    /// Delete a row in `table1`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::table1::dsl::*;
 

--- a/test/once_common_structs_once_connection_type/models/table1/generated.rs
+++ b/test/once_common_structs_once_connection_type/models/table1/generated.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use diesel::QueryResult;
 use crate::models::common::*;
 
+/// Struct representing a row in table `table1`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {

--- a/test/once_common_structs_once_connection_type/models/table1/generated.rs
+++ b/test/once_common_structs_once_connection_type/models/table1/generated.rs
@@ -10,6 +10,7 @@ use crate::models::common::*;
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {
+    /// Field representing column `id`
     pub id: i32,
 }
 

--- a/test/once_common_structs_once_connection_type/models/table2/generated.rs
+++ b/test/once_common_structs_once_connection_type/models/table2/generated.rs
@@ -10,6 +10,7 @@ use crate::models::common::*;
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {
+    /// Field representing column `id`
     pub id: i32,
 }
 

--- a/test/once_common_structs_once_connection_type/models/table2/generated.rs
+++ b/test/once_common_structs_once_connection_type/models/table2/generated.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use diesel::QueryResult;
 use crate::models::common::*;
 
+/// Struct representing a row in table `table2`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {

--- a/test/once_common_structs_once_connection_type/models/table2/generated.rs
+++ b/test/once_common_structs_once_connection_type/models/table2/generated.rs
@@ -15,12 +15,14 @@ pub struct Table2 {
 }
 
 impl Table2 {
+    /// Insert a new row into `table2` with all default values
     pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
         use crate::schema::table2::dsl::*;
 
         insert_into(table2).default_values().get_result::<Self>(db)
     }
 
+    /// Get a row from `table2`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::table2::dsl::*;
 
@@ -45,6 +47,7 @@ impl Table2 {
         })
     }
 
+    /// Delete a row in `table2`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::table2::dsl::*;
 

--- a/test/once_common_structs_once_connection_type_single_file/models/common.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/common.rs
@@ -1,11 +1,16 @@
 /* @generated and managed by dsync */
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/once_common_structs_once_connection_type_single_file/models/table1.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/table1.rs
@@ -15,12 +15,14 @@ pub struct Table1 {
 }
 
 impl Table1 {
+    /// Insert a new row into `table1` with all default values
     pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
         use crate::schema::table1::dsl::*;
 
         insert_into(table1).default_values().get_result::<Self>(db)
     }
 
+    /// Get a row from `table1`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::table1::dsl::*;
 
@@ -45,6 +47,7 @@ impl Table1 {
         })
     }
 
+    /// Delete a row in `table1`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::table1::dsl::*;
 

--- a/test/once_common_structs_once_connection_type_single_file/models/table1.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/table1.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use diesel::QueryResult;
 use crate::models::common::*;
 
+/// Struct representing a row in table `table1`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {

--- a/test/once_common_structs_once_connection_type_single_file/models/table1.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/table1.rs
@@ -10,6 +10,7 @@ use crate::models::common::*;
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {
+    /// Field representing column `id`
     pub id: i32,
 }
 

--- a/test/once_common_structs_once_connection_type_single_file/models/table2.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/table2.rs
@@ -10,6 +10,7 @@ use crate::models::common::*;
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {
+    /// Field representing column `id`
     pub id: i32,
 }
 

--- a/test/once_common_structs_once_connection_type_single_file/models/table2.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/table2.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use diesel::QueryResult;
 use crate::models::common::*;
 
+/// Struct representing a row in table `table2`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {

--- a/test/once_common_structs_once_connection_type_single_file/models/table2.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/table2.rs
@@ -15,12 +15,14 @@ pub struct Table2 {
 }
 
 impl Table2 {
+    /// Insert a new row into `table2` with all default values
     pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
         use crate::schema::table2::dsl::*;
 
         insert_into(table2).default_values().get_result::<Self>(db)
     }
 
+    /// Get a row from `table2`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::table2::dsl::*;
 
@@ -45,6 +47,7 @@ impl Table2 {
         })
     }
 
+    /// Delete a row in `table2`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::table2::dsl::*;
 

--- a/test/once_connection_type/models/table1/generated.rs
+++ b/test/once_connection_type/models/table1/generated.rs
@@ -14,13 +14,18 @@ pub struct Table1 {
     pub id: i32,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/once_connection_type/models/table1/generated.rs
+++ b/test/once_connection_type/models/table1/generated.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use diesel::QueryResult;
 use crate::models::common::*;
 
+/// Struct representing a row in table `table1`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {

--- a/test/once_connection_type/models/table1/generated.rs
+++ b/test/once_connection_type/models/table1/generated.rs
@@ -10,6 +10,7 @@ use crate::models::common::*;
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {
+    /// Field representing column `id`
     pub id: i32,
 }
 

--- a/test/once_connection_type/models/table1/generated.rs
+++ b/test/once_connection_type/models/table1/generated.rs
@@ -25,12 +25,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Table1 {
+    /// Insert a new row into `table1` with all default values
     pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
         use crate::schema::table1::dsl::*;
 
         insert_into(table1).default_values().get_result::<Self>(db)
     }
 
+    /// Get a row from `table1`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::table1::dsl::*;
 
@@ -55,6 +57,7 @@ impl Table1 {
         })
     }
 
+    /// Delete a row in `table1`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::table1::dsl::*;
 

--- a/test/once_connection_type/models/table2/generated.rs
+++ b/test/once_connection_type/models/table2/generated.rs
@@ -10,6 +10,7 @@ use crate::models::common::*;
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {
+    /// Field representing column `id`
     pub id: i32,
 }
 

--- a/test/once_connection_type/models/table2/generated.rs
+++ b/test/once_connection_type/models/table2/generated.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 use diesel::QueryResult;
 use crate::models::common::*;
 
+/// Struct representing a row in table `table2`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {

--- a/test/once_connection_type/models/table2/generated.rs
+++ b/test/once_connection_type/models/table2/generated.rs
@@ -25,12 +25,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Table2 {
+    /// Insert a new row into `table2` with all default values
     pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
         use crate::schema::table2::dsl::*;
 
         insert_into(table2).default_values().get_result::<Self>(db)
     }
 
+    /// Get a row from `table2`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::table2::dsl::*;
 
@@ -55,6 +57,7 @@ impl Table2 {
         })
     }
 
+    /// Delete a row in `table2`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::table2::dsl::*;
 

--- a/test/once_connection_type/models/table2/generated.rs
+++ b/test/once_connection_type/models/table2/generated.rs
@@ -14,13 +14,18 @@ pub struct Table2 {
     pub id: i32,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/readonly/models/normal/generated.rs
+++ b/test/readonly/models/normal/generated.rs
@@ -33,13 +33,18 @@ pub struct UpdateNormal {
     pub testprop: Option<i32>,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/readonly/models/normal/generated.rs
+++ b/test/readonly/models/normal/generated.rs
@@ -11,7 +11,9 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=normal, primary_key(id))]
 pub struct Normal {
+    /// Field representing column `id`
     pub id: i32,
+    /// Field representing column `testprop`
     pub testprop: i32,
 }
 
@@ -19,6 +21,7 @@ pub struct Normal {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=normal)]
 pub struct CreateNormal {
+    /// Field representing column `testprop`
     pub testprop: i32,
 }
 
@@ -26,6 +29,7 @@ pub struct CreateNormal {
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=normal)]
 pub struct UpdateNormal {
+    /// Field representing column `testprop`
     pub testprop: Option<i32>,
 }
 

--- a/test/readonly/models/normal/generated.rs
+++ b/test/readonly/models/normal/generated.rs
@@ -44,12 +44,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Normal {
+    /// Insert a new row into `normal` with a given [`CreateNormal`]
     pub fn create(db: &mut ConnectionType, item: &CreateNormal) -> QueryResult<Self> {
         use crate::schema::normal::dsl::*;
 
         insert_into(normal).values(item).get_result::<Self>(db)
     }
 
+    /// Get a row from `normal`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::normal::dsl::*;
 
@@ -74,12 +76,14 @@ impl Normal {
         })
     }
 
+    /// Update a row in `normal`, identified by the primary key with [`UpdateNormal`]
     pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateNormal) -> QueryResult<Self> {
         use crate::schema::normal::dsl::*;
 
         diesel::update(normal.filter(id.eq(param_id))).set(item).get_result(db)
     }
 
+    /// Delete a row in `normal`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::normal::dsl::*;
 

--- a/test/readonly/models/normal/generated.rs
+++ b/test/readonly/models/normal/generated.rs
@@ -7,6 +7,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `normal`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=normal, primary_key(id))]
 pub struct Normal {
@@ -14,12 +15,14 @@ pub struct Normal {
     pub testprop: i32,
 }
 
+/// Create Struct for a row in table `normal` for [`Normal`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=normal)]
 pub struct CreateNormal {
     pub testprop: i32,
 }
 
+/// Update Struct for a row in table `normal` for [`Normal`]
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=normal)]
 pub struct UpdateNormal {

--- a/test/readonly/models/prefixTable/generated.rs
+++ b/test/readonly/models/prefixTable/generated.rs
@@ -17,13 +17,18 @@ pub struct PrefixTable {
     pub testprop: i32,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/readonly/models/prefixTable/generated.rs
+++ b/test/readonly/models/prefixTable/generated.rs
@@ -28,6 +28,7 @@ pub struct PaginationResult<T> {
 }
 
 impl PrefixTable {
+    /// Get a row from `prefixTable`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::prefixTable::dsl::*;
 

--- a/test/readonly/models/prefixTable/generated.rs
+++ b/test/readonly/models/prefixTable/generated.rs
@@ -7,6 +7,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `prefixTable`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=prefixTable, primary_key(id))]
 pub struct PrefixTable {

--- a/test/readonly/models/prefixTable/generated.rs
+++ b/test/readonly/models/prefixTable/generated.rs
@@ -11,7 +11,9 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=prefixTable, primary_key(id))]
 pub struct PrefixTable {
+    /// Field representing column `id`
     pub id: i32,
+    /// Field representing column `testprop`
     pub testprop: i32,
 }
 

--- a/test/readonly/models/prefixTableSuffix/generated.rs
+++ b/test/readonly/models/prefixTableSuffix/generated.rs
@@ -28,6 +28,7 @@ pub struct PaginationResult<T> {
 }
 
 impl PrefixTableSuffix {
+    /// Get a row from `prefixTableSuffix`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::prefixTableSuffix::dsl::*;
 

--- a/test/readonly/models/prefixTableSuffix/generated.rs
+++ b/test/readonly/models/prefixTableSuffix/generated.rs
@@ -11,7 +11,9 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=prefixTableSuffix, primary_key(id))]
 pub struct PrefixTableSuffix {
+    /// Field representing column `id`
     pub id: i32,
+    /// Field representing column `testprop`
     pub testprop: i32,
 }
 

--- a/test/readonly/models/prefixTableSuffix/generated.rs
+++ b/test/readonly/models/prefixTableSuffix/generated.rs
@@ -17,13 +17,18 @@ pub struct PrefixTableSuffix {
     pub testprop: i32,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/readonly/models/prefixTableSuffix/generated.rs
+++ b/test/readonly/models/prefixTableSuffix/generated.rs
@@ -7,6 +7,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `prefixTableSuffix`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=prefixTableSuffix, primary_key(id))]
 pub struct PrefixTableSuffix {

--- a/test/readonly/models/tableSuffix/generated.rs
+++ b/test/readonly/models/tableSuffix/generated.rs
@@ -7,6 +7,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `tableSuffix`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=tableSuffix, primary_key(id))]
 pub struct TableSuffix {

--- a/test/readonly/models/tableSuffix/generated.rs
+++ b/test/readonly/models/tableSuffix/generated.rs
@@ -17,13 +17,18 @@ pub struct TableSuffix {
     pub testprop: i32,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/readonly/models/tableSuffix/generated.rs
+++ b/test/readonly/models/tableSuffix/generated.rs
@@ -11,7 +11,9 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=tableSuffix, primary_key(id))]
 pub struct TableSuffix {
+    /// Field representing column `id`
     pub id: i32,
+    /// Field representing column `testprop`
     pub testprop: i32,
 }
 

--- a/test/readonly/models/tableSuffix/generated.rs
+++ b/test/readonly/models/tableSuffix/generated.rs
@@ -28,6 +28,7 @@ pub struct PaginationResult<T> {
 }
 
 impl TableSuffix {
+    /// Get a row from `tableSuffix`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::tableSuffix::dsl::*;
 

--- a/test/simple_table/models/todos/generated.rs
+++ b/test/simple_table/models/todos/generated.rs
@@ -65,13 +65,18 @@ pub struct UpdateTodos {
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/simple_table/models/todos/generated.rs
+++ b/test/simple_table/models/todos/generated.rs
@@ -7,6 +7,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `todos`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
@@ -20,6 +21,7 @@ pub struct Todos {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
+/// Create Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
@@ -30,6 +32,7 @@ pub struct CreateTodos {
     pub type_: String,
 }
 
+/// Update Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {

--- a/test/simple_table/models/todos/generated.rs
+++ b/test/simple_table/models/todos/generated.rs
@@ -11,13 +11,21 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
+    /// Field representing column `id`
     pub id: i32,
+    /// Field representing column `unsigned`
     pub unsigned: u32,
+    /// Field representing column `unsigned_nullable`
     pub unsigned_nullable: Option<u32>,
+    /// Field representing column `text`
     pub text: String,
+    /// Field representing column `completed`
     pub completed: bool,
+    /// Field representing column `type`
     pub type_: String,
+    /// Field representing column `created_at`
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Field representing column `updated_at`
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -25,10 +33,15 @@ pub struct Todos {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
+    /// Field representing column `unsigned`
     pub unsigned: u32,
+    /// Field representing column `unsigned_nullable`
     pub unsigned_nullable: Option<u32>,
+    /// Field representing column `text`
     pub text: String,
+    /// Field representing column `completed`
     pub completed: bool,
+    /// Field representing column `type`
     pub type_: String,
 }
 
@@ -36,12 +49,19 @@ pub struct CreateTodos {
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
+    /// Field representing column `unsigned`
     pub unsigned: Option<u32>,
+    /// Field representing column `unsigned_nullable`
     pub unsigned_nullable: Option<Option<u32>>,
+    /// Field representing column `text`
     pub text: Option<String>,
+    /// Field representing column `completed`
     pub completed: Option<bool>,
+    /// Field representing column `type`
     pub type_: Option<String>,
+    /// Field representing column `created_at`
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Field representing column `updated_at`
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 

--- a/test/simple_table/models/todos/generated.rs
+++ b/test/simple_table/models/todos/generated.rs
@@ -76,12 +76,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Todos {
+    /// Insert a new row into `todos` with a given [`CreateTodos`]
     pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db)
     }
 
+    /// Get a row from `todos`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
@@ -106,12 +108,14 @@ impl Todos {
         })
     }
 
+    /// Update a row in `todos`, identified by the primary key with [`UpdateTodos`]
     pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)
     }
 
+    /// Delete a row in `todos`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::todos::dsl::*;
 

--- a/test/simple_table_async/models/todos/generated.rs
+++ b/test/simple_table_async/models/todos/generated.rs
@@ -54,13 +54,18 @@ pub struct UpdateTodos {
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/simple_table_async/models/todos/generated.rs
+++ b/test/simple_table_async/models/todos/generated.rs
@@ -12,11 +12,17 @@ type ConnectionType = diesel_async::pooled_connection::deadpool::Object<diesel_a
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
+    /// Field representing column `id`
     pub id: i32,
+    /// Field representing column `unsigned`
     pub unsigned: u32,
+    /// Field representing column `text`
     pub text: String,
+    /// Field representing column `completed`
     pub completed: bool,
+    /// Field representing column `created_at`
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Field representing column `updated_at`
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -24,8 +30,11 @@ pub struct Todos {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
+    /// Field representing column `unsigned`
     pub unsigned: u32,
+    /// Field representing column `text`
     pub text: String,
+    /// Field representing column `completed`
     pub completed: bool,
 }
 
@@ -33,10 +42,15 @@ pub struct CreateTodos {
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
+    /// Field representing column `unsigned`
     pub unsigned: Option<u32>,
+    /// Field representing column `text`
     pub text: Option<String>,
+    /// Field representing column `completed`
     pub completed: Option<bool>,
+    /// Field representing column `created_at`
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Field representing column `updated_at`
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 

--- a/test/simple_table_async/models/todos/generated.rs
+++ b/test/simple_table_async/models/todos/generated.rs
@@ -65,12 +65,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Todos {
+    /// Insert a new row into `todos` with a given [`CreateTodos`]
     pub async fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db).await
     }
 
+    /// Get a row from `todos`, identified by the primary key
     pub async fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
@@ -95,12 +97,14 @@ impl Todos {
         })
     }
 
+    /// Update a row in `todos`, identified by the primary key with [`UpdateTodos`]
     pub async fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db).await
     }
 
+    /// Delete a row in `todos`, identified by the primary key
     pub async fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::todos::dsl::*;
 

--- a/test/simple_table_async/models/todos/generated.rs
+++ b/test/simple_table_async/models/todos/generated.rs
@@ -8,6 +8,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel_async::pooled_connection::deadpool::Object<diesel_async::AsyncPgConnection>;
 
+/// Struct representing a row in table `todos`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
@@ -19,6 +20,7 @@ pub struct Todos {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
+/// Create Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
@@ -27,6 +29,7 @@ pub struct CreateTodos {
     pub completed: bool,
 }
 
+/// Update Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {

--- a/test/simple_table_custom_schema_path/models/todos/generated.rs
+++ b/test/simple_table_custom_schema_path/models/todos/generated.rs
@@ -64,12 +64,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Todos {
+    /// Insert a new row into `todos` with a given [`CreateTodos`]
     pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::data::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db)
     }
 
+    /// Get a row from `todos`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::data::schema::todos::dsl::*;
 
@@ -94,12 +96,14 @@ impl Todos {
         })
     }
 
+    /// Update a row in `todos`, identified by the primary key with [`UpdateTodos`]
     pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::data::schema::todos::dsl::*;
 
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)
     }
 
+    /// Delete a row in `todos`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::data::schema::todos::dsl::*;
 

--- a/test/simple_table_custom_schema_path/models/todos/generated.rs
+++ b/test/simple_table_custom_schema_path/models/todos/generated.rs
@@ -7,6 +7,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `todos`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
@@ -18,6 +19,7 @@ pub struct Todos {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
+/// Create Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
@@ -26,6 +28,7 @@ pub struct CreateTodos {
     pub completed: bool,
 }
 
+/// Update Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {

--- a/test/simple_table_custom_schema_path/models/todos/generated.rs
+++ b/test/simple_table_custom_schema_path/models/todos/generated.rs
@@ -53,13 +53,18 @@ pub struct UpdateTodos {
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/simple_table_custom_schema_path/models/todos/generated.rs
+++ b/test/simple_table_custom_schema_path/models/todos/generated.rs
@@ -11,11 +11,17 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
+    /// Field representing column `id`
     pub id: i32,
+    /// Field representing column `unsigned`
     pub unsigned: u32,
+    /// Field representing column `text`
     pub text: String,
+    /// Field representing column `completed`
     pub completed: bool,
+    /// Field representing column `created_at`
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Field representing column `updated_at`
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -23,8 +29,11 @@ pub struct Todos {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
+    /// Field representing column `unsigned`
     pub unsigned: u32,
+    /// Field representing column `text`
     pub text: String,
+    /// Field representing column `completed`
     pub completed: bool,
 }
 
@@ -32,10 +41,15 @@ pub struct CreateTodos {
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
+    /// Field representing column `unsigned`
     pub unsigned: Option<u32>,
+    /// Field representing column `text`
     pub text: Option<String>,
+    /// Field representing column `completed`
     pub completed: Option<bool>,
+    /// Field representing column `created_at`
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Field representing column `updated_at`
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 

--- a/test/simple_table_no_crud/models/todos/generated.rs
+++ b/test/simple_table_no_crud/models/todos/generated.rs
@@ -8,11 +8,17 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
+    /// Field representing column `id`
     pub id: i32,
+    /// Field representing column `unsigned`
     pub unsigned: u32,
+    /// Field representing column `text`
     pub text: String,
+    /// Field representing column `completed`
     pub completed: bool,
+    /// Field representing column `created_at`
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Field representing column `updated_at`
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -20,8 +26,11 @@ pub struct Todos {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
+    /// Field representing column `unsigned`
     pub unsigned: u32,
+    /// Field representing column `text`
     pub text: String,
+    /// Field representing column `completed`
     pub completed: bool,
 }
 
@@ -29,10 +38,15 @@ pub struct CreateTodos {
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
+    /// Field representing column `unsigned`
     pub unsigned: Option<u32>,
+    /// Field representing column `text`
     pub text: Option<String>,
+    /// Field representing column `completed`
     pub completed: Option<bool>,
+    /// Field representing column `created_at`
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Field representing column `updated_at`
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 

--- a/test/simple_table_no_crud/models/todos/generated.rs
+++ b/test/simple_table_no_crud/models/todos/generated.rs
@@ -4,6 +4,7 @@ use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 
+/// Struct representing a row in table `todos`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
@@ -15,6 +16,7 @@ pub struct Todos {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
+/// Create Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
@@ -23,6 +25,7 @@ pub struct CreateTodos {
     pub completed: bool,
 }
 
+/// Update Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {

--- a/test/simple_table_no_serde/models/todos/generated.rs
+++ b/test/simple_table_no_serde/models/todos/generated.rs
@@ -6,6 +6,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `todos`
 #[derive(Debug, Clone, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
@@ -17,6 +18,7 @@ pub struct Todos {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
+/// Create Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
@@ -25,6 +27,7 @@ pub struct CreateTodos {
     pub completed: bool,
 }
 
+/// Update Struct for a row in table `todos` for [`Todos`]
 #[derive(Debug, Clone, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {

--- a/test/simple_table_no_serde/models/todos/generated.rs
+++ b/test/simple_table_no_serde/models/todos/generated.rs
@@ -63,12 +63,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Todos {
+    /// Insert a new row into `todos` with a given [`CreateTodos`]
     pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         insert_into(todos).values(item).get_result::<Self>(db)
     }
 
+    /// Get a row from `todos`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
@@ -93,12 +95,14 @@ impl Todos {
         })
     }
 
+    /// Update a row in `todos`, identified by the primary key with [`UpdateTodos`]
     pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)
     }
 
+    /// Delete a row in `todos`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::todos::dsl::*;
 

--- a/test/simple_table_no_serde/models/todos/generated.rs
+++ b/test/simple_table_no_serde/models/todos/generated.rs
@@ -52,13 +52,18 @@ pub struct UpdateTodos {
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, )]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/simple_table_no_serde/models/todos/generated.rs
+++ b/test/simple_table_no_serde/models/todos/generated.rs
@@ -10,11 +10,17 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Queryable, Selectable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
+    /// Field representing column `id`
     pub id: i32,
+    /// Field representing column `unsigned`
     pub unsigned: u32,
+    /// Field representing column `text`
     pub text: String,
+    /// Field representing column `completed`
     pub completed: bool,
+    /// Field representing column `created_at`
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Field representing column `updated_at`
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -22,8 +28,11 @@ pub struct Todos {
 #[derive(Debug, Clone, Insertable)]
 #[diesel(table_name=todos)]
 pub struct CreateTodos {
+    /// Field representing column `unsigned`
     pub unsigned: u32,
+    /// Field representing column `text`
     pub text: String,
+    /// Field representing column `completed`
     pub completed: bool,
 }
 
@@ -31,10 +40,15 @@ pub struct CreateTodos {
 #[derive(Debug, Clone, AsChangeset, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
+    /// Field representing column `unsigned`
     pub unsigned: Option<u32>,
+    /// Field representing column `text`
     pub text: Option<String>,
+    /// Field representing column `completed`
     pub completed: Option<bool>,
+    /// Field representing column `created_at`
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Field representing column `updated_at`
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 

--- a/test/single_model_file/models/table1.rs
+++ b/test/single_model_file/models/table1.rs
@@ -26,12 +26,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Table1 {
+    /// Insert a new row into `table1` with all default values
     pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
         use crate::schema::table1::dsl::*;
 
         insert_into(table1).default_values().get_result::<Self>(db)
     }
 
+    /// Get a row from `table1`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::table1::dsl::*;
 
@@ -56,6 +58,7 @@ impl Table1 {
         })
     }
 
+    /// Delete a row in `table1`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::table1::dsl::*;
 

--- a/test/single_model_file/models/table1.rs
+++ b/test/single_model_file/models/table1.rs
@@ -15,13 +15,18 @@ pub struct Table1 {
     pub id: i32,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/single_model_file/models/table1.rs
+++ b/test/single_model_file/models/table1.rs
@@ -7,6 +7,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `table1`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {

--- a/test/single_model_file/models/table1.rs
+++ b/test/single_model_file/models/table1.rs
@@ -11,6 +11,7 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {
+    /// Field representing column `id`
     pub id: i32,
 }
 

--- a/test/single_model_file/models/table2.rs
+++ b/test/single_model_file/models/table2.rs
@@ -7,6 +7,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `table2`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {

--- a/test/single_model_file/models/table2.rs
+++ b/test/single_model_file/models/table2.rs
@@ -26,12 +26,14 @@ pub struct PaginationResult<T> {
 }
 
 impl Table2 {
+    /// Insert a new row into `table2` with all default values
     pub fn create(db: &mut ConnectionType) -> QueryResult<Self> {
         use crate::schema::table2::dsl::*;
 
         insert_into(table2).default_values().get_result::<Self>(db)
     }
 
+    /// Get a row from `table2`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> QueryResult<Self> {
         use crate::schema::table2::dsl::*;
 
@@ -56,6 +58,7 @@ impl Table2 {
         })
     }
 
+    /// Delete a row in `table2`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> QueryResult<usize> {
         use crate::schema::table2::dsl::*;
 

--- a/test/single_model_file/models/table2.rs
+++ b/test/single_model_file/models/table2.rs
@@ -11,6 +11,7 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {
+    /// Field representing column `id`
     pub id: i32,
 }
 

--- a/test/single_model_file/models/table2.rs
+++ b/test/single_model_file/models/table2.rs
@@ -15,13 +15,18 @@ pub struct Table2 {
     pub id: i32,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/use_statements/models/fang_tasks/generated.rs
+++ b/test/use_statements/models/fang_tasks/generated.rs
@@ -94,12 +94,14 @@ pub struct PaginationResult<T> {
 }
 
 impl FangTasks {
+    /// Insert a new row into `fang_tasks` with a given [`CreateFangTasks`]
     pub fn create(db: &mut ConnectionType, item: &CreateFangTasks) -> QueryResult<Self> {
         use crate::schema::fang_tasks::dsl::*;
 
         insert_into(fang_tasks).values(item).get_result::<Self>(db)
     }
 
+    /// Get a row from `fang_tasks`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: uuid::Uuid) -> QueryResult<Self> {
         use crate::schema::fang_tasks::dsl::*;
 
@@ -124,12 +126,14 @@ impl FangTasks {
         })
     }
 
+    /// Update a row in `fang_tasks`, identified by the primary key with [`UpdateFangTasks`]
     pub fn update(db: &mut ConnectionType, param_id: uuid::Uuid, item: &UpdateFangTasks) -> QueryResult<Self> {
         use crate::schema::fang_tasks::dsl::*;
 
         diesel::update(fang_tasks.filter(id.eq(param_id))).set(item).get_result(db)
     }
 
+    /// Delete a row in `fang_tasks`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: uuid::Uuid) -> QueryResult<usize> {
         use crate::schema::fang_tasks::dsl::*;
 

--- a/test/use_statements/models/fang_tasks/generated.rs
+++ b/test/use_statements/models/fang_tasks/generated.rs
@@ -7,6 +7,7 @@ use diesel::QueryResult;
 
 type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
+/// Struct representing a row in table `fang_tasks`
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=fang_tasks, primary_key(id))]
 pub struct FangTasks {
@@ -22,6 +23,7 @@ pub struct FangTasks {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
+/// Create Struct for a row in table `fang_tasks` for [`FangTasks`]
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=fang_tasks)]
 pub struct CreateFangTasks {
@@ -37,6 +39,7 @@ pub struct CreateFangTasks {
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
+/// Update Struct for a row in table `fang_tasks` for [`FangTasks`]
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=fang_tasks)]
 pub struct UpdateFangTasks {

--- a/test/use_statements/models/fang_tasks/generated.rs
+++ b/test/use_statements/models/fang_tasks/generated.rs
@@ -83,13 +83,18 @@ pub struct UpdateFangTasks {
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// Result of a `.paginate` function
 #[derive(Debug, Serialize)]
 pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
     pub items: Vec<T>,
+    /// The count of total items there are
     pub total_items: i64,
-    /// 0-based index
+    /// Current page, 0-based index
     pub page: i64,
+    /// Size of a page
     pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
 

--- a/test/use_statements/models/fang_tasks/generated.rs
+++ b/test/use_statements/models/fang_tasks/generated.rs
@@ -11,15 +11,25 @@ type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionMan
 #[derive(Debug, Clone, Serialize, Deserialize, Queryable, Selectable)]
 #[diesel(table_name=fang_tasks, primary_key(id))]
 pub struct FangTasks {
+    /// Field representing column `id`
     pub id: uuid::Uuid,
+    /// Field representing column `metadata`
     pub metadata: serde_json::Value,
+    /// Field representing column `error_message`
     pub error_message: Option<String>,
+    /// Field representing column `state`
     pub state: crate::schema::sql_types::FangTaskState,
+    /// Field representing column `task_type`
     pub task_type: String,
+    /// Field representing column `uniq_hash`
     pub uniq_hash: Option<String>,
+    /// Field representing column `retries`
     pub retries: i32,
+    /// Field representing column `scheduled_at`
     pub scheduled_at: chrono::DateTime<chrono::Utc>,
+    /// Field representing column `created_at`
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Field representing column `updated_at`
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -27,15 +37,25 @@ pub struct FangTasks {
 #[derive(Debug, Clone, Serialize, Deserialize, Insertable)]
 #[diesel(table_name=fang_tasks)]
 pub struct CreateFangTasks {
+    /// Field representing column `id`
     pub id: uuid::Uuid,
+    /// Field representing column `metadata`
     pub metadata: serde_json::Value,
+    /// Field representing column `error_message`
     pub error_message: Option<String>,
+    /// Field representing column `state`
     pub state: crate::schema::sql_types::FangTaskState,
+    /// Field representing column `task_type`
     pub task_type: String,
+    /// Field representing column `uniq_hash`
     pub uniq_hash: Option<String>,
+    /// Field representing column `retries`
     pub retries: i32,
+    /// Field representing column `scheduled_at`
     pub scheduled_at: chrono::DateTime<chrono::Utc>,
+    /// Field representing column `created_at`
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// Field representing column `updated_at`
     pub updated_at: chrono::DateTime<chrono::Utc>,
 }
 
@@ -43,14 +63,23 @@ pub struct CreateFangTasks {
 #[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
 #[diesel(table_name=fang_tasks)]
 pub struct UpdateFangTasks {
+    /// Field representing column `metadata`
     pub metadata: Option<serde_json::Value>,
+    /// Field representing column `error_message`
     pub error_message: Option<Option<String>>,
+    /// Field representing column `state`
     pub state: Option<crate::schema::sql_types::FangTaskState>,
+    /// Field representing column `task_type`
     pub task_type: Option<String>,
+    /// Field representing column `uniq_hash`
     pub uniq_hash: Option<Option<String>>,
+    /// Field representing column `retries`
     pub retries: Option<i32>,
+    /// Field representing column `scheduled_at`
     pub scheduled_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Field representing column `created_at`
     pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Field representing column `updated_at`
     pub updated_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 


### PR DESCRIPTION
This PR adds basic doc-comment generation for all generated structs, fields and functions.
The generated doc-comments currently do not include examples

re #56