### PR TITLE
Derive PartialEq for Update structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - list changes to files (unchanged, modified, deleted)
 - generate doc-comments for generated structs, fields and functions
 - add derive `QueryableByName` to read-structs
+- add derive `PartialEq` to update-structs
 
 ## 0.0.17 (yanked)
 

--- a/src/code.rs
+++ b/src/code.rs
@@ -127,6 +127,7 @@ pub mod derives {
     pub const ASSOCIATIONS: &str = "Associations";
     #[cfg(feature = "derive-queryablebyname")]
     pub const QUERYABLEBYNAME: &str = "QueryableByName";
+    pub const PARTIALEQ: &str = "PartialEq";
 }
 
 impl<'a> Struct<'a> {
@@ -207,6 +208,7 @@ impl<'a> Struct<'a> {
                     .all(|f| self.table.primary_key_column_names().contains(&f.name))
                 {
                     derives_vec.push(derives::ASCHANGESET);
+                    derives_vec.push(derives::PARTIALEQ);
                 }
 
                 derives_vec.push(derives::DEFAULT);

--- a/test/autogenerated_all/models/todos/generated.rs
+++ b/test/autogenerated_all/models/todos/generated.rs
@@ -18,7 +18,7 @@ pub struct Todos {
 }
 
 /// Update Struct for a row in table `todos` for [`Todos`]
-#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     /// Field representing column `created_at`

--- a/test/autogenerated_attributes/models/todos/generated.rs
+++ b/test/autogenerated_attributes/models/todos/generated.rs
@@ -26,7 +26,7 @@ pub struct CreateTodos {
 }
 
 /// Update Struct for a row in table `todos` for [`Todos`]
-#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     /// Field representing column `created_at`

--- a/test/autogenerated_primary_keys/models/todos/generated.rs
+++ b/test/autogenerated_primary_keys/models/todos/generated.rs
@@ -26,7 +26,7 @@ pub struct CreateTodos {
 }
 
 /// Update Struct for a row in table `todos` for [`Todos`]
-#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     /// Field representing column `text`

--- a/test/cleanup_generated_content/models/todos/generated.rs
+++ b/test/cleanup_generated_content/models/todos/generated.rs
@@ -36,7 +36,7 @@ pub struct CreateTodos {
 }
 
 /// Update Struct for a row in table `todos` for [`Todos`]
-#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     /// Field representing column `text`

--- a/test/create_update_str_cow/models/todos/generated.rs
+++ b/test/create_update_str_cow/models/todos/generated.rs
@@ -36,7 +36,7 @@ pub struct CreateTodos<'a> {
 }
 
 /// Update Struct for a row in table `todos` for [`Todos`]
-#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos<'a> {
     /// Field representing column `text_nullable`

--- a/test/create_update_str_str/models/todos/generated.rs
+++ b/test/create_update_str_str/models/todos/generated.rs
@@ -36,7 +36,7 @@ pub struct CreateTodos<'a> {
 }
 
 /// Update Struct for a row in table `todos` for [`Todos`]
-#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos<'a> {
     /// Field representing column `text_nullable`

--- a/test/custom_model_and_schema_path/models/tableB/generated.rs
+++ b/test/custom_model_and_schema_path/models/tableB/generated.rs
@@ -29,7 +29,7 @@ pub struct CreateTableB {
 }
 
 /// Update Struct for a row in table `tableB` for [`TableB`]
-#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=tableB)]
 pub struct UpdateTableB {
     /// Field representing column `link`

--- a/test/custom_model_path/models/tableB/generated.rs
+++ b/test/custom_model_path/models/tableB/generated.rs
@@ -29,7 +29,7 @@ pub struct CreateTableB {
 }
 
 /// Update Struct for a row in table `tableB` for [`TableB`]
-#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=tableB)]
 pub struct UpdateTableB {
     /// Field representing column `link`

--- a/test/multiple_primary_keys/models/users/generated.rs
+++ b/test/multiple_primary_keys/models/users/generated.rs
@@ -32,7 +32,7 @@ pub struct CreateUsers {
 }
 
 /// Update Struct for a row in table `users` for [`Users`]
-#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=users)]
 pub struct UpdateUsers {
     /// Field representing column `secret`

--- a/test/no_default_features/models/todos/generated.rs
+++ b/test/no_default_features/models/todos/generated.rs
@@ -46,7 +46,7 @@ pub struct CreateTodos {
 }
 
 /// Update Struct for a row in table `todos` for [`Todos`]
-#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     /// Field representing column `unsigned`

--- a/test/readonly/models/normal/generated.rs
+++ b/test/readonly/models/normal/generated.rs
@@ -26,7 +26,7 @@ pub struct CreateNormal {
 }
 
 /// Update Struct for a row in table `normal` for [`Normal`]
-#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=normal)]
 pub struct UpdateNormal {
     /// Field representing column `testprop`

--- a/test/simple_table/models/todos/generated.rs
+++ b/test/simple_table/models/todos/generated.rs
@@ -46,7 +46,7 @@ pub struct CreateTodos {
 }
 
 /// Update Struct for a row in table `todos` for [`Todos`]
-#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     /// Field representing column `unsigned`

--- a/test/simple_table_async/models/todos/generated.rs
+++ b/test/simple_table_async/models/todos/generated.rs
@@ -39,7 +39,7 @@ pub struct CreateTodos {
 }
 
 /// Update Struct for a row in table `todos` for [`Todos`]
-#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     /// Field representing column `unsigned`

--- a/test/simple_table_custom_schema_path/models/todos/generated.rs
+++ b/test/simple_table_custom_schema_path/models/todos/generated.rs
@@ -38,7 +38,7 @@ pub struct CreateTodos {
 }
 
 /// Update Struct for a row in table `todos` for [`Todos`]
-#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     /// Field representing column `unsigned`

--- a/test/simple_table_no_crud/models/todos/generated.rs
+++ b/test/simple_table_no_crud/models/todos/generated.rs
@@ -35,7 +35,7 @@ pub struct CreateTodos {
 }
 
 /// Update Struct for a row in table `todos` for [`Todos`]
-#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     /// Field representing column `unsigned`

--- a/test/simple_table_no_serde/models/todos/generated.rs
+++ b/test/simple_table_no_serde/models/todos/generated.rs
@@ -37,7 +37,7 @@ pub struct CreateTodos {
 }
 
 /// Update Struct for a row in table `todos` for [`Todos`]
-#[derive(Debug, Clone, AsChangeset, Default)]
+#[derive(Debug, Clone, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=todos)]
 pub struct UpdateTodos {
     /// Field representing column `unsigned`

--- a/test/use_statements/models/fang_tasks/generated.rs
+++ b/test/use_statements/models/fang_tasks/generated.rs
@@ -60,7 +60,7 @@ pub struct CreateFangTasks {
 }
 
 /// Update Struct for a row in table `fang_tasks` for [`FangTasks`]
-#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, AsChangeset, PartialEq, Default)]
 #[diesel(table_name=fang_tasks)]
 pub struct UpdateFangTasks {
     /// Field representing column `metadata`


### PR DESCRIPTION
To allow easy checks for "empty" updates, this change adds the PartialEq derive to the generated Update structs. This allows comparison with `Default::default()` to check if an update is empty.

Fixes: https://github.com/Wulf/dsync/issues/117