### PR TITLE
Revert "feat(code): use "use diesel" instead of "use crate::diesel""

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@
 - add many doc-comments to fields and functions
 - list changes to files (unchanged, modified, deleted)
 - generate doc-comments for generated structs, fields and functions
-- change the diesel import to be `use diesel` (instead of the previous `use crate::diesel`)
 - add derive `QueryableByName` to read-structs
 
 ## 0.0.17 (yanked)

--- a/src/code.rs
+++ b/src/code.rs
@@ -607,7 +607,7 @@ fn build_imports(table: &ParsedTableMacro, config: &GenerationConfig) -> String 
     // Note: i guess this could also just be a string that is appended to, or a vec of "Cow", but i personally think this is the most use-able
     // because you dont have to think of any context style (like forgetting to put "\n" before / after something)
     let mut imports_vec = Vec::with_capacity(10);
-    imports_vec.push("use diesel::*;".into());
+    imports_vec.push("use crate::diesel::*;".into());
 
     let table_options = config.table(&table.name.to_string());
     imports_vec.extend(table.foreign_keys.iter().map(|fk| {

--- a/test/autogenerated_all/models/todos/generated.rs
+++ b/test/autogenerated_all/models/todos/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/autogenerated_attributes/models/todos/generated.rs
+++ b/test/autogenerated_attributes/models/todos/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/autogenerated_primary_keys/models/todos/generated.rs
+++ b/test/autogenerated_primary_keys/models/todos/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/cleanup_generated_content/models/todos/generated.rs
+++ b/test/cleanup_generated_content/models/todos/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/create_update_str_cow/models/todos/generated.rs
+++ b/test/create_update_str_cow/models/todos/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/create_update_str_str/models/todos/generated.rs
+++ b/test/create_update_str_str/models/todos/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/custom_model_and_schema_path/models/tableA/generated.rs
+++ b/test/custom_model_and_schema_path/models/tableA/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::data::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/custom_model_and_schema_path/models/tableB/generated.rs
+++ b/test/custom_model_and_schema_path/models/tableB/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::data::models::table_a::TableA;
 use crate::data::schema::*;
 use serde::{Deserialize, Serialize};

--- a/test/custom_model_path/models/tableA/generated.rs
+++ b/test/custom_model_path/models/tableA/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/custom_model_path/models/tableB/generated.rs
+++ b/test/custom_model_path/models/tableB/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::data::models::table_a::TableA;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};

--- a/test/manual_primary_keys/models/todos/generated.rs
+++ b/test/manual_primary_keys/models/todos/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/multiple_primary_keys/models/users/generated.rs
+++ b/test/multiple_primary_keys/models/users/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/no_default_features/models/todos/generated.rs
+++ b/test/no_default_features/models/todos/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/once_common_structs/models/table1/generated.rs
+++ b/test/once_common_structs/models/table1/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/once_common_structs/models/table2/generated.rs
+++ b/test/once_common_structs/models/table2/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/once_common_structs_once_connection_type/models/table1/generated.rs
+++ b/test/once_common_structs_once_connection_type/models/table1/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/once_common_structs_once_connection_type/models/table2/generated.rs
+++ b/test/once_common_structs_once_connection_type/models/table2/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/once_common_structs_once_connection_type_single_file/models/table1.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/table1.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/once_common_structs_once_connection_type_single_file/models/table2.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/table2.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/once_connection_type/models/table1/generated.rs
+++ b/test/once_connection_type/models/table1/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/once_connection_type/models/table2/generated.rs
+++ b/test/once_connection_type/models/table2/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/readonly/models/normal/generated.rs
+++ b/test/readonly/models/normal/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/readonly/models/prefixTable/generated.rs
+++ b/test/readonly/models/prefixTable/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/readonly/models/prefixTableSuffix/generated.rs
+++ b/test/readonly/models/prefixTableSuffix/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/readonly/models/tableSuffix/generated.rs
+++ b/test/readonly/models/tableSuffix/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/simple_table/models/todos/generated.rs
+++ b/test/simple_table/models/todos/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/simple_table_async/models/todos/generated.rs
+++ b/test/simple_table_async/models/todos/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use diesel_async::RunQueryDsl;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};

--- a/test/simple_table_custom_schema_path/models/todos/generated.rs
+++ b/test/simple_table_custom_schema_path/models/todos/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::data::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/simple_table_no_crud/models/todos/generated.rs
+++ b/test/simple_table_no_crud/models/todos/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 

--- a/test/simple_table_no_serde/models/todos/generated.rs
+++ b/test/simple_table_no_serde/models/todos/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use diesel::QueryResult;
 

--- a/test/single_model_file/models/table1.rs
+++ b/test/single_model_file/models/table1.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/single_model_file/models/table2.rs
+++ b/test/single_model_file/models/table2.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;

--- a/test/use_statements/models/fang_tasks/generated.rs
+++ b/test/use_statements/models/fang_tasks/generated.rs
@@ -1,6 +1,6 @@
 /* @generated and managed by dsync */
 
-use diesel::*;
+use crate::diesel::*;
 use crate::schema::*;
 use serde::{Deserialize, Serialize};
 use diesel::QueryResult;


### PR DESCRIPTION
This reverts commit 5062ebe1d1e0ede5ee1865a0249c6f6f57bcd074.

because of #116

fixes #116 

re-opens #94 