### PR TITLE
Add semantic-release

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@61680d0e9b02ff86f5648ade99e01be17f0260a4 # v4
         with:
           dry_run: true
           extra_plugins: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
     name: cargo build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v3
@@ -35,7 +35,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
       - run: rustup component add clippy
@@ -53,7 +53,7 @@ jobs:
     needs: [build]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v3
@@ -71,7 +71,7 @@ jobs:
     name: cargo test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/cache@v3
@@ -88,7 +88,7 @@ jobs:
     name: cargo fmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
@@ -105,7 +105,7 @@ jobs:
       issues: write # for semantic-release to comment on and close issues
       pull-requests: write # for semantic-release to comment on and close pull requests
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -100,9 +100,25 @@ jobs:
     name: release
     needs: [build, clippy, test, test-script, fmt]
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write  # for actions/checkout to fetch code and for semantic-release to push commits, release releases and tags
+      issues: write # for semantic-release to comment on and close issues
+      pull-requests: write # for semantic-release to comment on and close pull requests
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo publish
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          dry_run: true
+          extra_plugins: |
+            @semantic-release/git
+            @semantic-release/changelog
+            @semantic-release/commit-analyzer
+            @semantic-release/release-notes-generator
+            @semantic-release/github
+            @semantic-release-cargo/semantic-release-cargo
+            @commitlint/config-conventional
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,0 +1,63 @@
+module.exports = {
+    plugins: [
+        [
+            '@semantic-release/commit-analyzer',
+            {
+                preset: 'angular',
+                releaseRules: [
+                    { breaking: true, release: 'major' },
+                    { type: 'feat', release: 'minor' },
+                    { type: 'fix', release: 'patch' },
+                    { type: 'docs', release: false },
+                    { type: 'style', release: false },
+                    { type: 'refactor', release: 'patch' },
+                    { type: 'perf', release: 'patch' },
+                    { type: 'test', release: false },
+                    { type: 'chore', release: false },
+                    { type: 'deps', release: 'minor' },
+                    { type: 'devdeps', release: false },
+                    { type: 'revert', release: 'patch' },
+                    // don't trigger another release on release commit
+                    { type: 'release', release: false }
+                ],
+                parserOpts: {
+                    noteKeywords: ['BREAKING CHANGE', 'BREAKING CHANGES']
+                }
+            }
+        ],
+        [
+            '@semantic-release/release-notes-generator',
+            {
+                preset: 'conventionalcommits',
+                presetConfig: {
+                    types: [
+                        { type: 'feat', section: 'Features' },
+                        { type: 'fix', section: 'Fixes' },
+                        { type: 'docs', hidden: true },
+                        { type: 'style', section: 'Style' },
+                        { type: 'refactor', section: 'Refactor' },
+                        { type: 'perf', section: 'Performance' },
+                        { type: 'test', hidden: true },
+                        { type: 'chore', hidden: true },
+                        { type: 'deps', section: 'Dependencies' },
+                        { type: 'devdeps', section: 'Dev-Dependencies' },
+                        { type: 'revert', section: 'Reverts' },
+                        { type: 'release', hidden: true }
+                    ]
+                }
+            }
+        ],
+        '@semantic-release/changelog',
+        '@semantic-release-cargo/semantic-release-cargo',
+        [
+            '@semantic-release/git', {
+                assets: ['Cargo.toml', 'Cargo.loc', 'CHANGELOG.md'],
+                message: 'release: v${nextRelease.version}'
+            }
+        ],
+        '@semantic-release/github'
+    ],
+    branches: [
+        'main',
+    ]
+};


### PR DESCRIPTION
This PR adds semantic-release for automatic:
- changelog generation
- versioning
- release commit
- publishing (to github and crates.io)
- adding comments to PRs & issues

Behavior:
- only gets run if manually triggered
- only runs on the `main` branch
- requires setup:
  - `CARGO_REGISTRY_TOKEN` cargo API token
  - consistent commit messages (commits not conforming are ignored)

<details>
<summary>Example Changelog entry generated for 0.1.0</summary>

---

## 0.1.0 (https://github.com/hasezoey/dsync/compare/v0.0.16...v0.1.0) (2023-11-10)

### Features

* add "error.rs" (0c84c15 (https://github.com/hasezoey/dsync/commit/0c84c151ebf34778e823301d861e5b453f634a47))
* add "once-common-structs" (5c07810 (https://github.com/hasezoey/dsync/commit/5c078105291c1d3b905ce62ee6511cc1fe0e3447))
* add "once-connection-type" (ac206e5 (https://github.com/hasezoey/dsync/commit/ac206e595a9aeeee104f40fb7ac1525070c765b9))
* add option "single-model-file" (405d25b (https://github.com/hasezoey/dsync/commit/405d25be0190e915f5b3e7196e2ab068e9797e96))
* add options "--readonly-*" (ab051c1 (https://github.com/hasezoey/dsync/commit/ab051c1d498bed117639acda0f836f3cb535537d)), closes #56 (https://github.com/hasezoey/dsync/issues/56)
* add options "create-str" and "update-str" (33ea467 (https://github.com/hasezoey/dsync/commit/33ea467391643c290b84610c6a286617f90fd578))
* code: add derive "QueryableByName" to read-structs (3f039b5 (https://github.com/hasezoey/dsync/commit/3f039b56a156bbc57290c81fc2450a27c4ff7660)), closes #97 (https://github.com/hasezoey/dsync/issues/97)
* code: add doccomments to "PaginationResult" structs (d6a764e (https://github.com/hasezoey/dsync/commit/d6a764e114ec0d33de344bfc45f319511896a309))
* code: add doccomments to generated fields of structs (533a472 (https://github.com/hasezoey/dsync/commit/533a472bc4f6662e89fe5e1cb2f887b7fd9c3ccf))
* code: add doccomments to generated functions (7525cda (https://github.com/hasezoey/dsync/commit/7525cdafae9aae7be411c98bf125f35c1c488d17))
* code: add doccomments to generated structs (11f18ec (https://github.com/hasezoey/dsync/commit/11f18ec59970cea705e785754f6818d2094848f0))
* code: derive "Default" for "Update" structs (#68 (https://github.com/hasezoey/dsync/issues/68)) (a2fd847 (https://github.com/hasezoey/dsync/commit/a2fd84773648a40bc62f9c85fd84fea3ba426f30))
* code: Derive PartialEq for Update structs (#118 (https://github.com/hasezoey/dsync/issues/118)) (c4697b2 (https://github.com/hasezoey/dsync/commit/c4697b28140dc844d8ac37288586b5d3be80439f))
* file: change "file_contents" to not be public (78dbb4b (https://github.com/hasezoey/dsync/commit/78dbb4bb715fb97fd4e93f1fbef3aa7c54e85642))
* lib: keep track of what happened to files (abf9dd3 (https://github.com/hasezoey/dsync/commit/abf9dd384d5dfbeb057994737c19cb4ce9679d08))
* main: make use of the new results and backtrace (863b317 (https://github.com/hasezoey/dsync/commit/863b317c87250316107a7f6559c6b314a169cdac))
* parser: parse actual column name from diesel macro (0fc74b0 (https://github.com/hasezoey/dsync/commit/0fc74b0804fd0e05be91272574eee1066228ef0c))
* replace "inflector" with "heck" also remove "to_singular" (5bc2bf6 (https://github.com/hasezoey/dsync/commit/5bc2bf6d2de897f2521a3c447a3e96fe1f06d74c))
* replace "structopt" with "clap" (#64 (https://github.com/hasezoey/dsync/issues/64)) (1937039 (https://github.com/hasezoey/dsync/commit/193703975be075a0f400081841038e5cddbc235a))
* replace most panics with results (32fd4c0 (https://github.com/hasezoey/dsync/commit/32fd4c041a91bff03e31116208213027f92b152e))

### Fixes

* code: add ending new-line to generated code (77ce422 (https://github.com/hasezoey/dsync/commit/77ce4224b01c47534973a64bc7b3318f48c0ff61))
* code: dont set "Some("")", use "None" (a8ce827 (https://github.com/hasezoey/dsync/commit/a8ce8278c4c94e24609581b4de0885039d5a2089))
* code: remove extra new-line between struct and paginationresult (2633bb8 (https://github.com/hasezoey/dsync/commit/2633bb83f5d4bad7a0ff7fbc7e8fd86ff7739a1b))
* code: rename "type Connection" to "type ConnectionType" (#60 (https://github.com/hasezoey/dsync/issues/60)) (3f98be6 (https://github.com/hasezoey/dsync/commit/3f98be63620352c2583146fb6bb037148eb90551))
* code: support for unsigned on nullable fields (#67 (https://github.com/hasezoey/dsync/issues/67)) (5b8cc31 (https://github.com/hasezoey/dsync/commit/5b8cc3185aa4268720f6199932f68664c9dc31be)), closes b41e14afc979ac144534e3d352bb8249f54fa967#r125954859 (https://github.com/hasezoey/b41e14afc979ac144534e3d352bb8249f54fa967/issues/r125954859)
* file: dont create empty file on new, only on "write" (826f738 (https://github.com/hasezoey/dsync/commit/826f738d37f9000f4afb84bce1ae2500ca490f46))
* lib: add ending new-line to generated "common.rs" files consistently (7a535c4 (https://github.com/hasezoey/dsync/commit/7a535c46d1337b69dd177df6e9e01d0ce958a9cc))

### Style

* add doc-comments to many fields and functions (#63 (https://github.com/hasezoey/dsync/issues/63)) (27193b5 (https://github.com/hasezoey/dsync/commit/27193b55bc14dbd367135474bb251c476d8029a0))
* add some missing rustdoc (c545123 (https://github.com/hasezoey/dsync/commit/c5451234c38dedf816264e4fe5abb009385e432b))
* apply clippy (non-auto) suggestions (#73 (https://github.com/hasezoey/dsync/issues/73)) (2a6a316 (https://github.com/hasezoey/dsync/commit/2a6a3162617f512a009693d3355b1f386eeb1651))
* apply clippy suggestion (7a71e47 (https://github.com/hasezoey/dsync/commit/7a71e475829d55a5433cc58915a7580b3b7375c4))
* code: change some "formatdoc!" macros to be spaced consistently (7fc95ce (https://github.com/hasezoey/dsync/commit/7fc95cea7955abebde9229c06aaea93d8405cdec))
* code: use "formatdoc!" over "format!(indoc!{" (91e6bf2 (https://github.com/hasezoey/dsync/commit/91e6bf2994a21578c22d315cfc96c36e8028e7e8))
* document what each feature does (8d0ece0 (https://github.com/hasezoey/dsync/commit/8d0ece0ea846ee093fe9799c1a1d65733191ac2c)), closes #91 (https://github.com/hasezoey/dsync/issues/91)
* error: fix some broken doc links because of enum rename (7b4a796 (https://github.com/hasezoey/dsync/commit/7b4a7968c25447d4bdedc14a0b7684d4c460fb8f))
* lib: fix some doc warnings (84c726d (https://github.com/hasezoey/dsync/commit/84c726d682df61e5cd232926caa5eb9e192ad625))

### Refactor

* code quality (some refactors) (#74 (https://github.com/hasezoey/dsync/issues/74)) (a0e77a8 (https://github.com/hasezoey/dsync/commit/a0e77a88c74fdbdd34572eeb023be589124cd066))
* code: add "derive(Debug)" where missing (9431fc0 (https://github.com/hasezoey/dsync/commit/9431fc00da23924ecde979ed0b1db2b9fad3728d))
* code: change "generate_connection_type" to not use new-lines (2253ae2 (https://github.com/hasezoey/dsync/commit/2253ae24596d9ff82396240096873d525fceaf2a))
* code: change "lines" init to be with capacity (e912cd2 (https://github.com/hasezoey/dsync/commit/e912cd26b72247a271e9dd3203a084d81b08b5b6))
* code: convert a "format!" to "formatdoc!" (471a035 (https://github.com/hasezoey/dsync/commit/471a035645e923cf04e188436dfc3bedd33615ba))
* code: earlier return if "fields" is empty (ee79ee7 (https://github.com/hasezoey/dsync/commit/ee79ee77cf74d849904de5b63c92f505f0b81d33))
* code: have less new-lines in impl block section (4a64dfe (https://github.com/hasezoey/dsync/commit/4a64dfef56df209b99026f9546b15084b2d955b2))
* code: improve handling of "StructField"s by splitting responsibility and improving documentation (d3014bd (https://github.com/hasezoey/dsync/commit/d3014bd91e869f9ae748c45446aad4ef88fa2a9b)), closes /github.com/Wulf/dsync/pull/83#issuecomment-1742059080 (https://github.com/hasezoey//github.com/Wulf/dsync/pull/83/issues/issuecomment-1742059080)
* code: only push struct code, if it actually is not empty (1e0b4d6 (https://github.com/hasezoey/dsync/commit/1e0b4d6752ee5ed54fd344315b9b14fc58e78000))
* code: refactor how derives are generated (dd44b25 (https://github.com/hasezoey/dsync/commit/dd44b25cb3458c229da681f2d7ddbd6b1070cdac)), closes #56 (https://github.com/hasezoey/dsync/issues/56)
* code: refactor how imports are generated / stored to be a vec (a8678c5 (https://github.com/hasezoey/dsync/commit/a8678c5b4cde67e4df25ae4bc286b0381a79f928))
* code: remove ".replace" by re-ordering what gets done first (a7aa3f4 (https://github.com/hasezoey/dsync/commit/a7aa3f4a4a0dd229850ed7e0cf51dd819eba2a37))
* code: remove "StructType::Form" (#72 (https://github.com/hasezoey/dsync/issues/72)) (4738d0f (https://github.com/hasezoey/dsync/commit/4738d0fbb74390558ac9b389b34e0840ed88f378)), closes #70 (https://github.com/hasezoey/dsync/issues/70)
* code: remove redundant variable re-definition (175aaa8 (https://github.com/hasezoey/dsync/commit/175aaa84502e342a265ad7e03f5c2c00ce3a8b6d))
* code: remove unused variable (81ead7a (https://github.com/hasezoey/dsync/commit/81ead7a3cd702b2b00aeebfe9cc90b5f4e83ad65))
* lib: pass reference to "generate_code" instead of whole config (c0c0b7c (https://github.com/hasezoey/dsync/commit/c0c0b7c0183292cbc5ad8778a0ce0e79ba89d132))

### Dependencies

* clap: update to 4.4 (d0669e6 (https://github.com/hasezoey/dsync/commit/d0669e6b03080005703206ed2baf4c8dc26757f0))
* indoc: update to 2.0.4 (2eeadcd (https://github.com/hasezoey/dsync/commit/2eeadcd4a9f49227fab81387750e22f28295f068))
* syn: update to 2 (f0c0192 (https://github.com/hasezoey/dsync/commit/f0c01929c722e6c2fc342daf5b779444a4c0a931))
* update Cargo.lock (c1e9565 (https://github.com/hasezoey/dsync/commit/c1e956580769eb8b62f3e0ef25051c6d2bf3675f))

---

</details>

fixes #71

PS: This PR is a draft, because 0.1.0 should likely be released manually (because the changelog already exists) and enforcing commit message style should come first (some commits since 0.0.16 to now do not follow that style and so would get ignored)