### PR TITLE
chore(workflows/CI): change git diff to not be quiet anymore

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,7 +64,7 @@ jobs:
             ~/.cargo
           key: ${{ runner.os }}-cargo-dev-${{ hashFiles('**/Cargo.lock') }}
       - run: bash test/test_all.sh
-      - run: git diff --exit-code --quiet || exit 1
+      - run: git diff --exit-code --stat || exit 1
 
   # things that use the cargo-test cache
   test:


### PR DESCRIPTION
This PR changes the CI's "git diff" test (which is used to check if the tests changed something that it shouldnt) to not be quiet anymore and list a summary of files which were changed to quickly see which tests failed.

previously:
```txt
$ git diff --exit-code --quiet
<no output>
```

now:
```txt
$ git diff --exit-code --stat
 src/code.rs                                                                | 2 +-
 test/autogenerated_all/models/todos/generated.rs                           | 2 +-
 test/autogenerated_attributes/models/todos/generated.rs                    | 2 +-
 test/autogenerated_primary_keys/models/todos/generated.rs                  | 2 +-
 test/cleanup_generated_content/models/todos/generated.rs                   | 2 +-
 test/create_update_bytes_cow/models/todos/generated.rs                     | 2 +-
 test/create_update_bytes_slice/models/todos/generated.rs                   | 2 +-
 test/create_update_str_cow/models/todos/generated.rs                       | 2 +-
 test/create_update_str_str/models/todos/generated.rs                       | 2 +-
 test/custom_model_and_schema_path/data/models/table_a/generated.rs         | 2 +-
 test/custom_model_and_schema_path/data/models/table_b/generated.rs         | 2 +-
 test/custom_model_path/models/table_a/generated.rs                         | 2 +-
 test/custom_model_path/models/table_b/generated.rs                         | 2 +-
 test/manual_primary_keys/models/todos/generated.rs                         | 2 +-
 test/multiple_primary_keys/models/users/generated.rs                       | 2 +-
 test/no_default_features/models/todos/generated.rs                         | 2 +-
 test/once_common_structs/models/common.rs                                  | 2 +-
 test/once_common_structs_once_connection_type/models/common.rs             | 2 +-
 test/once_common_structs_once_connection_type_single_file/models/common.rs | 2 +-
 test/once_connection_type/models/table1/generated.rs                       | 2 +-
 test/once_connection_type/models/table2/generated.rs                       | 2 +-
 test/readonly/models/normal/generated.rs                                   | 2 +-
 test/readonly/models/prefix_table/generated.rs                             | 2 +-
 test/readonly/models/prefix_table_suffix/generated.rs                      | 2 +-
 test/readonly/models/table_suffix/generated.rs                             | 2 +-
 test/simple_table/models/todos/generated.rs                                | 2 +-
 test/simple_table_async/models/todos/generated.rs                          | 2 +-
 test/simple_table_custom_schema_path/models/todos/generated.rs             | 2 +-
 test/simple_table_no_serde/models/todos/generated.rs                       | 2 +-
 test/single_model_file/models/table1.rs                                    | 2 +-
 test/single_model_file/models/table2.rs                                    | 2 +-
 test/use_statements/models/fang_tasks/generated.rs                         | 2 +-
 32 files changed, 32 insertions(+), 32 deletions(-)
```

alternatively, we could also just remove that parameter to print the full diff of each file (which would be quite verbose)