### PR TITLE
WIP: try to use `quote` + `prettyplease`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "heck",
  "indoc",
  "proc-macro2",
+ "quote",
  "syn",
  "thiserror",
 ]
@@ -161,18 +162,18 @@ checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -198,9 +199,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ dependencies = [
  "clap_complete",
  "heck",
  "indoc",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "syn",
@@ -159,6 +160,16 @@ name = "linux-raw-sys"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ advanced-queries = []
 clap = { version = "4.4", features = ["derive", "wrap_help"] }
 clap_complete = "4.4"
 syn = { version = "2", features = ["extra-traits", "full"] }
+quote = "1"
 proc-macro2 = "1"
 indoc = "2.0.4"
 heck = "0.4" # same case converter diesel uses

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ clap = { version = "4.4", features = ["derive", "wrap_help"] }
 clap_complete = "4.4"
 syn = { version = "2", features = ["extra-traits", "full"] }
 quote = "1"
+prettyplease = "0.2"
 proc-macro2 = "1"
 indoc = "2.0.4"
 heck = "0.4" # same case converter diesel uses

--- a/test/advanced_queries/models/todos/generated.rs
+++ b/test/advanced_queries/models/todos/generated.rs
@@ -77,20 +77,20 @@ pub struct PaginationResult<T> {
     /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
-
 impl Todos {
     /// Insert a new row into `todos` with a given [`CreateTodos`]
-    pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> diesel::QueryResult<Self> {
+    pub fn create(
+        db: &mut ConnectionType,
+        item: &CreateTodos,
+    ) -> diesel::QueryResult<Self> {
         use crate::schema::todos::dsl::*;
         diesel::insert_into(todos).values(item).get_result::<Self>(db)
     }
-
     /// Get a row from `todos`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> diesel::QueryResult<Self> {
         use crate::schema::todos::dsl::*;
         todos.filter(id.eq(param_id)).first::<Self>(db)
     }
-
     /// Paginates through the table where page is a 0-based index (i.e. page 0 is the first page)
     pub fn paginate(
         db: &mut ConnectionType,
@@ -114,21 +114,20 @@ impl Todos {
             num_pages: total_items / page_size + i64::from(total_items % page_size != 0),
         })
     }
-
     /** A utility function to help build custom search queries
-    
-    Example:
-    
-    ```
-    // create a filter for completed todos
-    let query = Todo::filter(TodoFilter {
-        completed: Some(true),
-        ..Default::default()
-    });
-    
-    // delete completed todos
-    diesel::delete(query).execute(db)?;
-    ```*/
+
+Example:
+
+```
+// create a filter for completed todos
+let query = Todo::filter(TodoFilter {
+    completed: Some(true),
+    ..Default::default()
+});
+
+// delete completed todos
+diesel::delete(query).execute(db)?;
+```*/
     pub fn filter<'a>(
         filter: TodosFilter,
     ) -> crate::schema::todos::BoxedQuery<'a, diesel::pg::Pg> {
@@ -159,7 +158,6 @@ impl Todos {
         }
         query
     }
-
     /// Update a row in `todos`, identified by the primary key with [`UpdateTodos`]
     pub fn update(
         db: &mut ConnectionType,
@@ -169,14 +167,12 @@ impl Todos {
         use crate::schema::todos::dsl::*;
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)
     }
-
     /// Delete a row in `todos`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> diesel::QueryResult<usize> {
         use crate::schema::todos::dsl::*;
         diesel::delete(todos.filter(id.eq(param_id))).execute(db)
     }
 }
-
 #[derive(Debug, Default, Clone)]
 pub struct TodosFilter {
     pub id: Option<i32>,

--- a/test/simple_table_pg/models/mod.rs
+++ b/test/simple_table_pg/models/mod.rs
@@ -1,1 +1,2 @@
 pub mod todos;
+pub mod todos2;

--- a/test/simple_table_pg/models/todos/generated.rs
+++ b/test/simple_table_pg/models/todos/generated.rs
@@ -77,20 +77,20 @@ pub struct PaginationResult<T> {
     /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
-
 impl Todos {
     /// Insert a new row into `todos` with a given [`CreateTodos`]
-    pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> diesel::QueryResult<Self> {
+    pub fn create(
+        db: &mut ConnectionType,
+        item: &CreateTodos,
+    ) -> diesel::QueryResult<Self> {
         use crate::schema::todos::dsl::*;
         diesel::insert_into(todos).values(item).get_result::<Self>(db)
     }
-
     /// Get a row from `todos`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> diesel::QueryResult<Self> {
         use crate::schema::todos::dsl::*;
         todos.filter(id.eq(param_id)).first::<Self>(db)
     }
-
     /// Update a row in `todos`, identified by the primary key with [`UpdateTodos`]
     pub fn update(
         db: &mut ConnectionType,
@@ -100,7 +100,6 @@ impl Todos {
         use crate::schema::todos::dsl::*;
         diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)
     }
-
     /// Delete a row in `todos`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> diesel::QueryResult<usize> {
         use crate::schema::todos::dsl::*;

--- a/test/simple_table_pg/models/todos/generated.rs
+++ b/test/simple_table_pg/models/todos/generated.rs
@@ -88,21 +88,20 @@ impl Todos {
     /// Get a row from `todos`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> diesel::QueryResult<Self> {
         use crate::schema::todos::dsl::*;
-
         todos.filter(id.eq(param_id)).first::<Self>(db)
     }
 
     /// Update a row in `todos`, identified by the primary key with [`UpdateTodos`]
-    pub fn update(db: &mut ConnectionType, param_id: i32, item: &UpdateTodos) -> diesel::QueryResult<Self> {
+    pub fn update(db: &mut ConnectionType, param_id : i32, item: &UpdateTodos) -> diesel::QueryResult<Self> {
         use crate::schema::todos::dsl::*;
 
-        diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)
+        diesel::update(todos.filter (id . eq (param_id))).set(item).get_result(db)
     }
 
     /// Delete a row in `todos`, identified by the primary key
-    pub fn delete(db: &mut ConnectionType, param_id: i32) -> diesel::QueryResult<usize> {
+    pub fn delete(db: &mut ConnectionType, param_id : i32) -> diesel::QueryResult<usize> {
         use crate::schema::todos::dsl::*;
 
-        diesel::delete(todos.filter(id.eq(param_id))).execute(db)
+        diesel::delete(todos.filter (id . eq (param_id))).execute(db)
     }
 }

--- a/test/simple_table_pg/models/todos/generated.rs
+++ b/test/simple_table_pg/models/todos/generated.rs
@@ -92,16 +92,18 @@ impl Todos {
     }
 
     /// Update a row in `todos`, identified by the primary key with [`UpdateTodos`]
-    pub fn update(db: &mut ConnectionType, param_id : i32, item: &UpdateTodos) -> diesel::QueryResult<Self> {
+    pub fn update(
+        db: &mut ConnectionType,
+        param_id: i32,
+        item: &UpdateTodos,
+    ) -> diesel::QueryResult<Self> {
         use crate::schema::todos::dsl::*;
-
-        diesel::update(todos.filter (id . eq (param_id))).set(item).get_result(db)
+        diesel::update(todos.filter(id.eq(param_id))).set(item).get_result(db)
     }
 
     /// Delete a row in `todos`, identified by the primary key
-    pub fn delete(db: &mut ConnectionType, param_id : i32) -> diesel::QueryResult<usize> {
+    pub fn delete(db: &mut ConnectionType, param_id: i32) -> diesel::QueryResult<usize> {
         use crate::schema::todos::dsl::*;
-
-        diesel::delete(todos.filter (id . eq (param_id))).execute(db)
+        diesel::delete(todos.filter(id.eq(param_id))).execute(db)
     }
 }

--- a/test/simple_table_pg/models/todos/generated.rs
+++ b/test/simple_table_pg/models/todos/generated.rs
@@ -82,7 +82,6 @@ impl Todos {
     /// Insert a new row into `todos` with a given [`CreateTodos`]
     pub fn create(db: &mut ConnectionType, item: &CreateTodos) -> diesel::QueryResult<Self> {
         use crate::schema::todos::dsl::*;
-
         diesel::insert_into(todos).values(item).get_result::<Self>(db)
     }
 

--- a/test/simple_table_pg/models/todos2/generated.rs
+++ b/test/simple_table_pg/models/todos2/generated.rs
@@ -32,7 +32,6 @@ impl Todos2 {
     /// Insert a new row into `todos2` with all default values
     pub fn create(db: &mut ConnectionType) -> diesel::QueryResult<Self> {
         use crate::schema::todos2::dsl::*;
-
         diesel::insert_into(todos2).default_values().get_result::<Self>(db)
     }
 

--- a/test/simple_table_pg/models/todos2/generated.rs
+++ b/test/simple_table_pg/models/todos2/generated.rs
@@ -27,20 +27,17 @@ pub struct PaginationResult<T> {
     /// Number of total possible pages, given the `page_size` and `total_items`
     pub num_pages: i64,
 }
-
 impl Todos2 {
     /// Insert a new row into `todos2` with all default values
     pub fn create(db: &mut ConnectionType) -> diesel::QueryResult<Self> {
         use crate::schema::todos2::dsl::*;
         diesel::insert_into(todos2).default_values().get_result::<Self>(db)
     }
-
     /// Get a row from `todos2`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> diesel::QueryResult<Self> {
         use crate::schema::todos2::dsl::*;
         todos2.filter(id.eq(param_id)).first::<Self>(db)
     }
-
     /// Delete a row in `todos2`, identified by the primary key
     pub fn delete(db: &mut ConnectionType, param_id: i32) -> diesel::QueryResult<usize> {
         use crate::schema::todos2::dsl::*;

--- a/test/simple_table_pg/models/todos2/generated.rs
+++ b/test/simple_table_pg/models/todos2/generated.rs
@@ -38,14 +38,13 @@ impl Todos2 {
     /// Get a row from `todos2`, identified by the primary key
     pub fn read(db: &mut ConnectionType, param_id: i32) -> diesel::QueryResult<Self> {
         use crate::schema::todos2::dsl::*;
-
         todos2.filter(id.eq(param_id)).first::<Self>(db)
     }
 
     /// Delete a row in `todos2`, identified by the primary key
-    pub fn delete(db: &mut ConnectionType, param_id: i32) -> diesel::QueryResult<usize> {
+    pub fn delete(db: &mut ConnectionType, param_id : i32) -> diesel::QueryResult<usize> {
         use crate::schema::todos2::dsl::*;
 
-        diesel::delete(todos2.filter(id.eq(param_id))).execute(db)
+        diesel::delete(todos2.filter (id . eq (param_id))).execute(db)
     }
 }

--- a/test/simple_table_pg/models/todos2/generated.rs
+++ b/test/simple_table_pg/models/todos2/generated.rs
@@ -42,9 +42,8 @@ impl Todos2 {
     }
 
     /// Delete a row in `todos2`, identified by the primary key
-    pub fn delete(db: &mut ConnectionType, param_id : i32) -> diesel::QueryResult<usize> {
+    pub fn delete(db: &mut ConnectionType, param_id: i32) -> diesel::QueryResult<usize> {
         use crate::schema::todos2::dsl::*;
-
-        diesel::delete(todos2.filter (id . eq (param_id))).execute(db)
+        diesel::delete(todos2.filter(id.eq(param_id))).execute(db)
     }
 }

--- a/test/simple_table_pg/models/todos2/generated.rs
+++ b/test/simple_table_pg/models/todos2/generated.rs
@@ -1,0 +1,52 @@
+/* @generated and managed by dsync */
+
+use crate::diesel::*;
+use crate::schema::*;
+
+pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
+
+/// Struct representing a row in table `todos2`
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[diesel(table_name=todos2, primary_key(id))]
+pub struct Todos2 {
+    /// Field representing column `id`
+    pub id: i32,
+}
+
+/// Result of a `.paginate` function
+#[derive(Debug, serde::Serialize)]
+pub struct PaginationResult<T> {
+    /// Resulting items that are from the current page
+    pub items: Vec<T>,
+    /// The count of total items there are
+    pub total_items: i64,
+    /// Current page, 0-based index
+    pub page: i64,
+    /// Size of a page
+    pub page_size: i64,
+    /// Number of total possible pages, given the `page_size` and `total_items`
+    pub num_pages: i64,
+}
+
+impl Todos2 {
+    /// Insert a new row into `todos2` with all default values
+    pub fn create(db: &mut ConnectionType) -> diesel::QueryResult<Self> {
+        use crate::schema::todos2::dsl::*;
+
+        diesel::insert_into(todos2).default_values().get_result::<Self>(db)
+    }
+
+    /// Get a row from `todos2`, identified by the primary key
+    pub fn read(db: &mut ConnectionType, param_id: i32) -> diesel::QueryResult<Self> {
+        use crate::schema::todos2::dsl::*;
+
+        todos2.filter(id.eq(param_id)).first::<Self>(db)
+    }
+
+    /// Delete a row in `todos2`, identified by the primary key
+    pub fn delete(db: &mut ConnectionType, param_id: i32) -> diesel::QueryResult<usize> {
+        use crate::schema::todos2::dsl::*;
+
+        diesel::delete(todos2.filter(id.eq(param_id))).execute(db)
+    }
+}

--- a/test/simple_table_pg/models/todos2/mod.rs
+++ b/test/simple_table_pg/models/todos2/mod.rs
@@ -1,0 +1,2 @@
+pub mod generated;
+pub use generated::*;

--- a/test/simple_table_pg/schema.rs
+++ b/test/simple_table_pg/schema.rs
@@ -12,7 +12,6 @@ diesel::table! {
         updated_at -> Timestamp,
     }
 }
-
 diesel::table! {
     todos2 (id) {
         id -> Int4,

--- a/test/simple_table_pg/schema.rs
+++ b/test/simple_table_pg/schema.rs
@@ -12,3 +12,9 @@ diesel::table! {
         updated_at -> Timestamp,
     }
 }
+
+diesel::table! {
+    todos2 (id) {
+        id -> Int4,
+    }
+}


### PR DESCRIPTION
This PR is a POC (which may be extended upon) to use `quote` + `prettyplease` for code generation instead of a string.

limitations i have found while using quote + syn + prettyplease:
- does not preserve empty new lines
- doc-comments will either get formatted as `/** */` if multiline
- does not preserve comments (that are not doc-comments)
- does not indent multiline doc-comments
- doc-comments have to be done in a separate variable, because quote does not allow interpolation in a comment

aside from those problems there are some things which could be done, but i have not done yet:
- re-order the functions so that only one `buffer` is required (cannot add a beginning `impl` and a end `impl` like a string)
- refactor structs / functions to use proc-macro2 / syn types (as to not require so much `syn::parse`)

re #105

PS: i know the tests are failing, i have just included 2 updated test cases which cover the all the cases this PR touches, and to simplify a quick review

---

my personal opinion is that at least in the current state (see limitations), the string representation is a lot better; but we should maybe still store proc-macro2 / syn types in things like `StructField` or names, to maybe ensure they are valid idents and stuff