### PR TITLE
Quick-fix unused import warnings of generated code

### DIFF
--- a/src/code.rs
+++ b/src/code.rs
@@ -729,7 +729,7 @@ fn build_imports(table: &ParsedTableMacro, config: &GenerationConfig) -> String 
     // Note: i guess this could also just be a string that is appended to, or a vec of "Cow", but i personally think this is the most use-able
     // because you dont have to think of any context style (like forgetting to put "\n" before / after something)
     let mut imports_vec = Vec::with_capacity(10);
-    imports_vec.push("use crate::diesel::*;".into());
+    imports_vec.push("#[allow(unused)]\nuse crate::diesel::*;".into());
 
     let table_options = config.table(&table.name.to_string());
     imports_vec.extend(table.foreign_keys.iter().map(|fk| {

--- a/src/code.rs
+++ b/src/code.rs
@@ -537,8 +537,6 @@ fn build_table_fns(
     buffer.push_str(&format!(r##"
     /// Paginates through the table where page is a 0-based index (i.e. page 0 is the first page)
     pub{async_keyword} fn paginate(db: &mut ConnectionType, page: i64, page_size: i64, filter: {struct_name}Filter) -> diesel::QueryResult<PaginationResult<Self>> {{
-        use {schema_path}{table_name}::dsl::*;
-
         let page = page.max(0);
         let page_size = page_size.max(1);
         let total_items = Self::filter(filter.clone()).count().get_result(db){await_keyword}?;

--- a/test/advanced_queries/models/todos/generated.rs
+++ b/test/advanced_queries/models/todos/generated.rs
@@ -96,8 +96,6 @@ impl Todos {
 
     /// Paginates through the table where page is a 0-based index (i.e. page 0 is the first page)
     pub fn paginate(db: &mut ConnectionType, page: i64, page_size: i64, filter: TodosFilter) -> diesel::QueryResult<PaginationResult<Self>> {
-        use crate::schema::todos::dsl::*;
-
         let page = page.max(0);
         let page_size = page_size.max(1);
         let total_items = Self::filter(filter.clone()).count().get_result(db)?;

--- a/test/advanced_queries/models/todos/generated.rs
+++ b/test/advanced_queries/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/autogenerated_all/models/todos/generated.rs
+++ b/test/autogenerated_all/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/autogenerated_attributes/models/todos/generated.rs
+++ b/test/autogenerated_attributes/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/autogenerated_primary_keys/models/todos/generated.rs
+++ b/test/autogenerated_primary_keys/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/cleanup_generated_content/models/todos/generated.rs
+++ b/test/cleanup_generated_content/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/create_update_bytes_cow/models/todos/generated.rs
+++ b/test/create_update_bytes_cow/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/create_update_bytes_slice/models/todos/generated.rs
+++ b/test/create_update_bytes_slice/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/create_update_str_cow/models/todos/generated.rs
+++ b/test/create_update_str_cow/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/create_update_str_str/models/todos/generated.rs
+++ b/test/create_update_str_str/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/custom_model_and_schema_path/data/models/table_a/generated.rs
+++ b/test/custom_model_and_schema_path/data/models/table_a/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::data::schema::*;
 

--- a/test/custom_model_and_schema_path/data/models/table_b/generated.rs
+++ b/test/custom_model_and_schema_path/data/models/table_b/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::data::models::table_a::TableA;
 use crate::data::schema::*;

--- a/test/custom_model_path/models/table_a/generated.rs
+++ b/test/custom_model_path/models/table_a/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/custom_model_path/models/table_b/generated.rs
+++ b/test/custom_model_path/models/table_b/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::data::models::table_a::TableA;
 use crate::schema::*;

--- a/test/manual_primary_keys/models/todos/generated.rs
+++ b/test/manual_primary_keys/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/multiple_primary_keys/models/users/generated.rs
+++ b/test/multiple_primary_keys/models/users/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/no_default_features/models/todos/generated.rs
+++ b/test/no_default_features/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/once_common_structs/models/table1/generated.rs
+++ b/test/once_common_structs/models/table1/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 use crate::models::common::*;

--- a/test/once_common_structs/models/table2/generated.rs
+++ b/test/once_common_structs/models/table2/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 use crate::models::common::*;

--- a/test/once_common_structs_once_connection_type/models/table1/generated.rs
+++ b/test/once_common_structs_once_connection_type/models/table1/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 use crate::models::common::*;

--- a/test/once_common_structs_once_connection_type/models/table2/generated.rs
+++ b/test/once_common_structs_once_connection_type/models/table2/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 use crate::models::common::*;

--- a/test/once_common_structs_once_connection_type_single_file/models/table1.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/table1.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 use crate::models::common::*;

--- a/test/once_common_structs_once_connection_type_single_file/models/table2.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/table2.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 use crate::models::common::*;

--- a/test/once_connection_type/models/table1/generated.rs
+++ b/test/once_connection_type/models/table1/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 use crate::models::common::*;

--- a/test/once_connection_type/models/table2/generated.rs
+++ b/test/once_connection_type/models/table2/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 use crate::models::common::*;

--- a/test/postgres_array_column/models/user/generated.rs
+++ b/test/postgres_array_column/models/user/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/readonly/models/normal/generated.rs
+++ b/test/readonly/models/normal/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/readonly/models/prefix_table/generated.rs
+++ b/test/readonly/models/prefix_table/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/readonly/models/prefix_table_suffix/generated.rs
+++ b/test/readonly/models/prefix_table_suffix/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/readonly/models/table_suffix/generated.rs
+++ b/test/readonly/models/table_suffix/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/simple_table_async/models/todos/generated.rs
+++ b/test/simple_table_async/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use diesel_async::RunQueryDsl;
 use crate::schema::*;

--- a/test/simple_table_custom_schema_path/models/todos/generated.rs
+++ b/test/simple_table_custom_schema_path/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::data::schema::*;
 

--- a/test/simple_table_mysql/models/todos/generated.rs
+++ b/test/simple_table_mysql/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/simple_table_no_crud/models/todos/generated.rs
+++ b/test/simple_table_no_crud/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/simple_table_no_serde/models/todos/generated.rs
+++ b/test/simple_table_no_serde/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/simple_table_pg/models/todos/generated.rs
+++ b/test/simple_table_pg/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/simple_table_sqlite/models/todos/generated.rs
+++ b/test/simple_table_sqlite/models/todos/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/single_model_file/models/table1.rs
+++ b/test/single_model_file/models/table1.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/single_model_file/models/table2.rs
+++ b/test/single_model_file/models/table2.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 

--- a/test/use_statements/models/fang_tasks/generated.rs
+++ b/test/use_statements/models/fang_tasks/generated.rs
@@ -1,5 +1,6 @@
 /* @generated and managed by dsync */
 
+#[allow(unused)]
 use crate::diesel::*;
 use crate::schema::*;
 


### PR DESCRIPTION
This PR quick-fixes the unused import warnings for `crate::diesel::*` and paginate imports.
The `crate::diesel::*` line should be removed altogether (see #94).

re https://github.com/Wulf/dsync/issues/94#issuecomment-1937836230