### PR TITLE
Derive "diesel::Identifiable" if struct has a primary-key

### DIFF
--- a/src/code.rs
+++ b/src/code.rs
@@ -213,6 +213,8 @@ impl<'a> Struct<'a> {
 
                 if !self.table.foreign_keys.is_empty() {
                     derives_vec.extend_from_slice(&[derives::ASSOCIATIONS, derives::IDENTIFIABLE]);
+                } else if !self.table.primary_key_columns.is_empty() {
+                    derives_vec.push(derives::IDENTIFIABLE);
                 }
             }
             StructType::Update => {

--- a/test/advanced_queries/models/todos/generated.rs
+++ b/test/advanced_queries/models/todos/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     /// Field representing column `id`

--- a/test/autogenerated_all/models/todos/generated.rs
+++ b/test/autogenerated_all/models/todos/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     /// Field representing column `id`

--- a/test/autogenerated_attributes/models/todos/generated.rs
+++ b/test/autogenerated_attributes/models/todos/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     /// Field representing column `id`

--- a/test/autogenerated_primary_keys/models/todos/generated.rs
+++ b/test/autogenerated_primary_keys/models/todos/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     /// Field representing column `id`

--- a/test/cleanup_generated_content/models/todos/generated.rs
+++ b/test/cleanup_generated_content/models/todos/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     /// Field representing column `id`

--- a/test/create_update_bytes_cow/models/todos/generated.rs
+++ b/test/create_update_bytes_cow/models/todos/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(data))]
 pub struct Todos {
     /// Field representing column `data`

--- a/test/create_update_bytes_slice/models/todos/generated.rs
+++ b/test/create_update_bytes_slice/models/todos/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(data))]
 pub struct Todos {
     /// Field representing column `data`

--- a/test/create_update_str_cow/models/todos/generated.rs
+++ b/test/create_update_str_cow/models/todos/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(text))]
 pub struct Todos {
     /// Field representing column `text`

--- a/test/create_update_str_str/models/todos/generated.rs
+++ b/test/create_update_str_str/models/todos/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(text))]
 pub struct Todos {
     /// Field representing column `text`

--- a/test/custom_model_and_schema_path/data/models/table_a/generated.rs
+++ b/test/custom_model_and_schema_path/data/models/table_a/generated.rs
@@ -7,7 +7,7 @@ use crate::data::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `tableA`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=tableA, primary_key(_id))]
 pub struct TableA {
     /// Field representing column `_id`

--- a/test/custom_model_path/models/table_a/generated.rs
+++ b/test/custom_model_path/models/table_a/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `tableA`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=tableA, primary_key(_id))]
 pub struct TableA {
     /// Field representing column `_id`

--- a/test/manual_primary_keys/models/todos/generated.rs
+++ b/test/manual_primary_keys/models/todos/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     /// Field representing column `id`

--- a/test/multiple_primary_keys/models/users/generated.rs
+++ b/test/multiple_primary_keys/models/users/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `users`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=users, primary_key(name,address))]
 pub struct Users {
     /// Field representing column `name`

--- a/test/no_default_features/models/todos/generated.rs
+++ b/test/no_default_features/models/todos/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::PgConnection>>;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     /// Field representing column `id`

--- a/test/once_common_structs/models/table1/generated.rs
+++ b/test/once_common_structs/models/table1/generated.rs
@@ -8,7 +8,7 @@ use crate::models::common::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `table1`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {
     /// Field representing column `id`

--- a/test/once_common_structs/models/table2/generated.rs
+++ b/test/once_common_structs/models/table2/generated.rs
@@ -8,7 +8,7 @@ use crate::models::common::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `table2`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {
     /// Field representing column `id`

--- a/test/once_common_structs_once_connection_type/models/table1/generated.rs
+++ b/test/once_common_structs_once_connection_type/models/table1/generated.rs
@@ -6,7 +6,7 @@ use crate::schema::*;
 use crate::models::common::*;
 
 /// Struct representing a row in table `table1`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {
     /// Field representing column `id`

--- a/test/once_common_structs_once_connection_type/models/table2/generated.rs
+++ b/test/once_common_structs_once_connection_type/models/table2/generated.rs
@@ -6,7 +6,7 @@ use crate::schema::*;
 use crate::models::common::*;
 
 /// Struct representing a row in table `table2`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {
     /// Field representing column `id`

--- a/test/once_common_structs_once_connection_type_single_file/models/table1.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/table1.rs
@@ -6,7 +6,7 @@ use crate::schema::*;
 use crate::models::common::*;
 
 /// Struct representing a row in table `table1`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {
     /// Field representing column `id`

--- a/test/once_common_structs_once_connection_type_single_file/models/table2.rs
+++ b/test/once_common_structs_once_connection_type_single_file/models/table2.rs
@@ -6,7 +6,7 @@ use crate::schema::*;
 use crate::models::common::*;
 
 /// Struct representing a row in table `table2`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {
     /// Field representing column `id`

--- a/test/once_connection_type/models/table1/generated.rs
+++ b/test/once_connection_type/models/table1/generated.rs
@@ -6,7 +6,7 @@ use crate::schema::*;
 use crate::models::common::*;
 
 /// Struct representing a row in table `table1`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {
     /// Field representing column `id`

--- a/test/once_connection_type/models/table2/generated.rs
+++ b/test/once_connection_type/models/table2/generated.rs
@@ -6,7 +6,7 @@ use crate::schema::*;
 use crate::models::common::*;
 
 /// Struct representing a row in table `table2`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {
     /// Field representing column `id`

--- a/test/postgres_array_column/models/user/generated.rs
+++ b/test/postgres_array_column/models/user/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `user`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=user, primary_key(id))]
 pub struct User {
     /// Field representing column `id`

--- a/test/readonly/models/normal/generated.rs
+++ b/test/readonly/models/normal/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `normal`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=normal, primary_key(id))]
 pub struct Normal {
     /// Field representing column `id`

--- a/test/readonly/models/prefix_table/generated.rs
+++ b/test/readonly/models/prefix_table/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `prefixTable`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=prefixTable, primary_key(id))]
 pub struct PrefixTable {
     /// Field representing column `id`

--- a/test/readonly/models/prefix_table_suffix/generated.rs
+++ b/test/readonly/models/prefix_table_suffix/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `prefixTableSuffix`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=prefixTableSuffix, primary_key(id))]
 pub struct PrefixTableSuffix {
     /// Field representing column `id`

--- a/test/readonly/models/table_suffix/generated.rs
+++ b/test/readonly/models/table_suffix/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `tableSuffix`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=tableSuffix, primary_key(id))]
 pub struct TableSuffix {
     /// Field representing column `id`

--- a/test/simple_table_async/models/todos/generated.rs
+++ b/test/simple_table_async/models/todos/generated.rs
@@ -8,7 +8,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel_async::pooled_connection::deadpool::Object<diesel_async::AsyncPgConnection>;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     /// Field representing column `id`

--- a/test/simple_table_custom_schema_path/models/todos/generated.rs
+++ b/test/simple_table_custom_schema_path/models/todos/generated.rs
@@ -7,7 +7,7 @@ use crate::data::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     /// Field representing column `id`

--- a/test/simple_table_mysql/models/todos/generated.rs
+++ b/test/simple_table_mysql/models/todos/generated.rs
@@ -5,7 +5,7 @@ use crate::diesel::*;
 use crate::schema::*;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     /// Field representing column `id`

--- a/test/simple_table_no_crud/models/todos/generated.rs
+++ b/test/simple_table_no_crud/models/todos/generated.rs
@@ -5,7 +5,7 @@ use crate::diesel::*;
 use crate::schema::*;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     /// Field representing column `id`

--- a/test/simple_table_no_serde/models/todos/generated.rs
+++ b/test/simple_table_no_serde/models/todos/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     /// Field representing column `id`

--- a/test/simple_table_pg/models/todos/generated.rs
+++ b/test/simple_table_pg/models/todos/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     /// Field representing column `id`

--- a/test/simple_table_sqlite/models/todos/generated.rs
+++ b/test/simple_table_sqlite/models/todos/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::sqlite::SqliteConnection>>;
 
 /// Struct representing a row in table `todos`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=todos, primary_key(id))]
 pub struct Todos {
     /// Field representing column `id`

--- a/test/single_model_file/models/table1.rs
+++ b/test/single_model_file/models/table1.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `table1`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=table1, primary_key(id))]
 pub struct Table1 {
     /// Field representing column `id`

--- a/test/single_model_file/models/table2.rs
+++ b/test/single_model_file/models/table2.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `table2`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=table2, primary_key(id))]
 pub struct Table2 {
     /// Field representing column `id`

--- a/test/use_statements/models/fang_tasks/generated.rs
+++ b/test/use_statements/models/fang_tasks/generated.rs
@@ -7,7 +7,7 @@ use crate::schema::*;
 pub type ConnectionType = diesel::r2d2::PooledConnection<diesel::r2d2::ConnectionManager<diesel::pg::PgConnection>>;
 
 /// Struct representing a row in table `fang_tasks`
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, diesel::Queryable, diesel::Selectable, diesel::QueryableByName, diesel::Identifiable)]
 #[diesel(table_name=fang_tasks, primary_key(id))]
 pub struct FangTasks {
     /// Field representing column `id`


### PR DESCRIPTION
This PR adds derive `diesel::Identifiable` to all Read-structs which have a primary key.

fixes #133

Note: personally i thought the `Identifiable` is only necessary for `Associations` or if you want to use the struct directly in a `update` (see doc quote)

> This must be implemented to use associations.
> Additionally, implementing this trait allows you to pass your struct to `update` (`update(&your_struct)` is equivalent to `update(YourStruct::table().find(&your_struct.primary_key())`

[source](https://docs.rs/diesel/2.1.4/diesel/associations/trait.Identifiable.html)

---

@longsleep does this properly fix you case? also could you explain why it would be necessary aside from `Associations` or is the second "helper"(the `update(&struct)`) the reason?