### PR TITLE
[src/{bin/main,global,lib}.rs] Add new `additional_derives` vec CLI opt…

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -139,7 +139,7 @@ pub struct MainOptions {
 
     /// Add these additional derives to each generated `struct`
     #[arg(short = 'd', long = "derive")]
-    pub additional_derives: Option<Vec<String>>,
+    pub additional_derives: Vec<String>,
 }
 
 #[derive(Debug, ValueEnum, Clone, PartialEq, Default)]
@@ -269,7 +269,7 @@ fn actual_main() -> dsync::Result<()> {
                 once_connection_type: args.once_connection_type,
                 readonly_prefixes: args.readonly_prefixes,
                 readonly_suffixes: args.readonly_suffixes,
-                additional_derives: args.additional_derives.unwrap_or(Default::default()),
+                additional_derives: args.additional_derives,
             },
         },
     )?;

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -269,7 +269,7 @@ fn actual_main() -> dsync::Result<()> {
                 once_connection_type: args.once_connection_type,
                 readonly_prefixes: args.readonly_prefixes,
                 readonly_suffixes: args.readonly_suffixes,
-                additional_derives: args.additional_derives
+                additional_derives: args.additional_derives,
             },
         },
     )?;

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -136,6 +136,10 @@ pub struct MainOptions {
     /// See `crate::GenerationConfig::diesel_backend` for more details.
     #[arg(short = 'b', long = "diesel-backend")]
     pub diesel_backend: String,
+
+    /// Add these additional derives to each generated `struct`
+    #[arg(short = 'd', long = "derive")]
+    pub additional_derives: Option<Vec<String>>,
 }
 
 #[derive(Debug, ValueEnum, Clone, PartialEq, Default)]
@@ -265,6 +269,7 @@ fn actual_main() -> dsync::Result<()> {
                 once_connection_type: args.once_connection_type,
                 readonly_prefixes: args.readonly_prefixes,
                 readonly_suffixes: args.readonly_suffixes,
+                additional_derives: args.additional_derives
             },
         },
     )?;

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -269,7 +269,7 @@ fn actual_main() -> dsync::Result<()> {
                 once_connection_type: args.once_connection_type,
                 readonly_prefixes: args.readonly_prefixes,
                 readonly_suffixes: args.readonly_suffixes,
-                additional_derives: args.additional_derives,
+                additional_derives: args.additional_derives.unwrap_or(Default::default()),
             },
         },
     )?;

--- a/src/code.rs
+++ b/src/code.rs
@@ -193,13 +193,19 @@ impl<'a> Struct<'a> {
 
     /// Assemble the `derive` attribute for the struct
     fn attr_derive(&self) -> String {
-        let mut derives_vec = match &self.config.options.additional_derives {
-            Some(v) => {
-                let mut _derives_vec = Vec::<&str>::with_capacity(10 + v.len());
-                _derives_vec.extend(v.iter().map(|s| -> &str { s.as_ref() }));
-                _derives_vec
-            }
-            None => Vec::with_capacity(10),
+        let mut derives_vec = if self.config.options.additional_derives.is_empty() {
+            Vec::with_capacity(10)
+        } else {
+            let mut _derives_vec =
+                Vec::<&str>::with_capacity(10 + self.config.options.additional_derives.len());
+            _derives_vec.extend(
+                self.config
+                    .options
+                    .additional_derives
+                    .iter()
+                    .map(|s| -> &str { s.as_ref() }),
+            );
+            _derives_vec
         };
         // Default derives that exist on every struct
         derives_vec.extend_from_slice(&[derives::DEBUG, derives::CLONE]);

--- a/src/code.rs
+++ b/src/code.rs
@@ -196,7 +196,6 @@ impl<'a> Struct<'a> {
         let mut derives_vec = match &self.config.options.additional_derives {
             Some(v) => {
                 let mut _derives_vec = Vec::<&str>::with_capacity(10 + v.len());
-                // _derives_vec.extend(v.iter().map(AsRef::as_ref).iter())
                 _derives_vec.extend(v.iter().map(|s| -> &str { s.as_ref() }));
                 _derives_vec
             },

--- a/src/code.rs
+++ b/src/code.rs
@@ -198,8 +198,8 @@ impl<'a> Struct<'a> {
                 let mut _derives_vec = Vec::<&str>::with_capacity(10 + v.len());
                 _derives_vec.extend(v.iter().map(|s| -> &str { s.as_ref() }));
                 _derives_vec
-            },
-            None => Vec::with_capacity(10)
+            }
+            None => Vec::with_capacity(10),
         };
         // Default derives that exist on every struct
         derives_vec.extend_from_slice(&[derives::DEBUG, derives::CLONE]);

--- a/src/code.rs
+++ b/src/code.rs
@@ -86,7 +86,7 @@ pub struct StructField {
 
 impl StructField {
     /// Assemble the current options into a rust type, like `base_type: String, is_optional: true` to `Option<String>`
-    pub fn to_rust_type(&self) -> Cow<str> {
+    pub fn to_rust_type(&self) -> Cow<'_, str> {
         let mut rust_type = self.base_type.clone();
 
         // order matters!
@@ -193,7 +193,15 @@ impl<'a> Struct<'a> {
 
     /// Assemble the `derive` attribute for the struct
     fn attr_derive(&self) -> String {
-        let mut derives_vec = Vec::with_capacity(10);
+        let mut derives_vec = match &self.config.options.additional_derives {
+            Some(v) => {
+                let mut _derives_vec = Vec::<&str>::with_capacity(10 + v.len());
+                // _derives_vec.extend(v.iter().map(AsRef::as_ref).iter())
+                _derives_vec.extend(v.iter().map(|s| -> &str { s.as_ref() }));
+                _derives_vec
+            },
+            None => Vec::with_capacity(10)
+        };
         // Default derives that exist on every struct
         derives_vec.extend_from_slice(&[derives::DEBUG, derives::CLONE]);
 

--- a/src/code.rs
+++ b/src/code.rs
@@ -193,20 +193,17 @@ impl<'a> Struct<'a> {
 
     /// Assemble the `derive` attribute for the struct
     fn attr_derive(&self) -> String {
-        let mut derives_vec = if self.config.options.additional_derives.is_empty() {
-            Vec::with_capacity(10)
-        } else {
-            let mut _derives_vec =
-                Vec::<&str>::with_capacity(10 + self.config.options.additional_derives.len());
-            _derives_vec.extend(
+        let mut derives_vec =
+            Vec::<&str>::with_capacity(10 + self.config.options.additional_derives.len());
+        if !self.config.options.additional_derives.is_empty() {
+            derives_vec.extend(
                 self.config
                     .options
                     .additional_derives
                     .iter()
                     .map(|s| -> &str { s.as_ref() }),
             );
-            _derives_vec
-        };
+        }
         // Default derives that exist on every struct
         derives_vec.extend_from_slice(&[derives::DEBUG, derives::CLONE]);
 

--- a/src/global.rs
+++ b/src/global.rs
@@ -330,7 +330,7 @@ pub struct GenerationConfigOpts<'a> {
     pub readonly_suffixes: Vec<String>,
 
     /// Add these additional derives to each generated `struct`
-    pub additional_derives: Option<Vec<String>>
+    pub additional_derives: Option<Vec<String>>,
 }
 
 impl GenerationConfigOpts<'_> {

--- a/src/global.rs
+++ b/src/global.rs
@@ -328,6 +328,9 @@ pub struct GenerationConfigOpts<'a> {
     pub readonly_prefixes: Vec<String>,
     /// Suffixes to treat tables as readonly
     pub readonly_suffixes: Vec<String>,
+
+    /// Add these additional derives to each generated `struct`
+    pub additional_derives: Option<Vec<String>>
 }
 
 impl GenerationConfigOpts<'_> {
@@ -363,6 +366,7 @@ impl Default for GenerationConfigOpts<'_> {
             once_connection_type: false,
             readonly_prefixes: Vec::default(),
             readonly_suffixes: Vec::default(),
+            additional_derives: None,
         }
     }
 }

--- a/src/global.rs
+++ b/src/global.rs
@@ -330,7 +330,7 @@ pub struct GenerationConfigOpts<'a> {
     pub readonly_suffixes: Vec<String>,
 
     /// Add these additional derives to each generated `struct`
-    pub additional_derives: Option<Vec<String>>,
+    pub additional_derives: Vec<String>,
 }
 
 impl GenerationConfigOpts<'_> {
@@ -366,7 +366,7 @@ impl Default for GenerationConfigOpts<'_> {
             once_connection_type: false,
             readonly_prefixes: Vec::default(),
             readonly_suffixes: Vec::default(),
-            additional_derives: None,
+            additional_derives: Vec::default(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(iter_collect_into)]
 //! dsync library
 //!
 //! The dsync library allows creating a custom binary for dsync

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(iter_collect_into)]
 //! dsync library
 //!
 //! The dsync library allows creating a custom binary for dsync


### PR DESCRIPTION
; [src/code.rs] Fix type elision warning


Basically I am getting this issue:
```
error[E0277]: the trait bound `models::profiles_tbl::generated::CreateProfilesTbl: ToSchema` is not satisfied
  --> src/routes/profile.rs:67:32
   |
67 |     form: actix_web::web::Json<CreateProfilesTbl>,
   |                                ^^^^^^^^^^^^^^^^^ unsatisfied trait bound
```

[`utoipa::ToSchema`](https://docs.rs/utoipa/latest/utoipa/derive.ToSchema.html) needs to be on the `struct`. But it's a bit too specific to make it to this library/cli, and regardless doesn't futureproof dsync.

So this just lets you add arbitrary derives as strings. As many as your heart desires.

# `--help`
```
  -d, --derive <ADDITIONAL_DERIVES>
          Add these additional derives to each generated `struct`
```