### PR TITLE
Fix new rust & clippy warnings; Simplify CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,13 +19,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v3
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ./.cargo/.build
-            ./target
-            ~/.cargo
-          key: ${{ runner.os }}-cargo-dev-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: "build"
       - run: cargo build --all-targets
 
   clippy:
@@ -37,13 +33,9 @@ jobs:
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
       - run: rustup component add clippy
-      - uses: actions/cache@v3
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ./.cargo/.build
-            ./target
-            ~/.cargo
-          key: ${{ runner.os }}-cargo-dev-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: "build"
       - run: cargo clippy --all
 
   test-script:
@@ -54,13 +46,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v3
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ./.cargo/.build
-            ./target
-            ~/.cargo
-          key: ${{ runner.os }}-cargo-dev-${{ hashFiles('**/Cargo.lock') }}
+          shared-key: "build"
       - run: bash test/test_all.sh
       - run: git diff --exit-code --stat || exit 1
 
@@ -72,13 +60,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ./.cargo/.build
-            ./target
-            ~/.cargo
-          key: ${{ runner.os }}-cargo-test-${{ hashFiles('**/Cargo.lock') }}
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test
 
   # Things that don't need a cache

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,11 +14,17 @@ concurrency:
 jobs:
   build:
     name: cargo build
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        rust: [stable, "1.70"]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ matrix.rust }}
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "build"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: rui314/setup-mold@v1
       - uses: dtolnay/rust-toolchain@stable
-      - run: rustup component add clippy
+        with:
+          components: clippy
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "build"
@@ -68,7 +69,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: nightly
-      - run: rustup component add rustfmt
+          components: rustfmt
       - run: cargo fmt --all -- --check
 
   release:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   build:
-    name: cargo build
+    name: cargo build & test
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -29,6 +29,7 @@ jobs:
         with:
           shared-key: "build"
       - run: cargo build --all-targets
+      - run: cargo test
 
   clippy:
     name: cargo clippy
@@ -58,17 +59,6 @@ jobs:
       - run: bash test/test_all.sh
       - run: git diff --exit-code --stat || exit 1
 
-  # things that use the cargo-test cache
-  test:
-    name: cargo test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: rui314/setup-mold@v1
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo test
-
   # Things that don't need a cache
   fmt:
     name: cargo fmt
@@ -84,7 +74,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     name: release
-    needs: [build, clippy, test, test-script, fmt]
+    needs: [build, clippy, test-script, fmt]
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
     permissions:
       contents: write  # for actions/checkout to fetch code and for semantic-release to push commits, release releases and tags

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,6 @@
 name: CI
 on:
   push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## next
+
+- set MSRV to `1.70`
+
 ## 0.1.0
 
 - replace `structopt` with `clap`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ authors = [
     "hasezoey <hasezoey@gmail.com>",
 ]
 edition = "2021"
+rust-version = "1.70"
 
 [features]
 default = ["tsync", "backtrace", "derive-queryablebyname"]

--- a/src/code.rs
+++ b/src/code.rs
@@ -86,7 +86,7 @@ pub struct StructField {
 
 impl StructField {
     /// Assemble the current options into a rust type, like `base_type: String, is_optional: true` to `Option<String>`
-    pub fn to_rust_type(&self) -> Cow<str> {
+    pub fn to_rust_type(&self) -> Cow<'_, str> {
         let mut rust_type = self.base_type.clone();
 
         // order matters!

--- a/src/error.rs
+++ b/src/error.rs
@@ -61,10 +61,10 @@ impl Error {
         M: Into<String>,
         P: AsRef<Path>,
     {
-        return Self::new(ErrorEnum::IoError(
+        Self::new(ErrorEnum::IoError(
             ioError::new(kind, msg.into()),
             format_path(path.as_ref().to_string_lossy().to_string()),
-        ));
+        ))
     }
 
     pub fn not_a_directory<M, P>(msg: M, path: P) -> Self
@@ -72,10 +72,10 @@ impl Error {
         M: Into<String>,
         P: AsRef<Path>,
     {
-        return Self::new(ErrorEnum::NotADirectory(
+        Self::new(ErrorEnum::NotADirectory(
             msg.into(),
             path.as_ref().to_string_lossy().to_string(),
-        ));
+        ))
     }
 }
 
@@ -87,7 +87,7 @@ impl std::fmt::Display for Error {
 
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        return self.source.source();
+        self.source.source()
     }
 }
 
@@ -148,13 +148,13 @@ pub trait IOErrorToError<T> {
 
 impl<T> IOErrorToError<T> for std::result::Result<T, std::io::Error> {
     fn attach_path_err<P: AsRef<Path>>(self, path: P) -> Result<T> {
-        return match self {
+        match self {
             Ok(v) => Ok(v),
             Err(e) => Err(crate::Error::new(ErrorEnum::IoError(
                 e,
                 format_path(path.as_ref().to_string_lossy().to_string()),
             ))),
-        };
+        }
     }
 
     fn attach_path_msg<P: AsRef<Path>, M: AsRef<str>>(self, path: P, msg: M) -> Result<T> {


### PR DESCRIPTION
This PR fixes new warnings by rust and clippy and also simplifies the CI workflow by:
- combining build & test jobs
- switching to `Swatinem/rust-cache` for our caching needs
- directly install components instead of another step
- test MSRV in addition to stable
- enable workflow run on any branch

Finally, set a MSRV as listed on [lib.rs](https://lib.rs/crates/dsync/versions) (older *may* work, but didnt test)