### PR TITLE
[src/global.rs] Get `cargo test --all-features` to pass

### DIFF
--- a/src/global.rs
+++ b/src/global.rs
@@ -394,14 +394,16 @@ pub struct GenerationConfig<'a> {
     /// ```
     /// # use dsync::{GenerationConfig,GenerationConfigOpts};
     /// GenerationConfig {
-    ///  // ... all required options
-    ///  # connection_type: String::default(),
+    ///  // ... all required options, for example:
+    ///  connection_type: String::from("diesel::sqlite::SqliteConnection"),
+    ///  diesel_backend: String::from("diesel::sqlite::Sqlite"),
     ///  options: Default::default(),
     /// };
     /// // or
     /// GenerationConfig {
-    ///  // ... all required options
-    ///  # connection_type: String::default(),
+    ///  // ... all required options, for example:
+    ///  connection_type: String::from("diesel::sqlite::SqliteConnection"),
+    ///  diesel_backend: String::from("diesel::sqlite::Sqlite"),
     ///  options: GenerationConfigOpts {
     ///    ..Default::default()
     ///  },


### PR DESCRIPTION
Before:
```
$ cargo test --all-features

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test src/global.rs - global::GenerationConfig::options (line 394) ... FAILED

failures:

---- src/global.rs - global::GenerationConfig::options (line 394) stdout ----
[0m[1m[38;5;9merror[E0063][0m[0m[1m: missing field `diesel_backend` in initializer of `GenerationConfig<'_>`[0m
[0m [0m[0m[1m[38;5;12m--> [0m[0msrc/global.rs:397:1[0m
[0m  [0m[0m[1m[38;5;12m|[0m
[0m[1m[38;5;12m6[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0mGenerationConfig {[0m
[0m  [0m[0m[1m[38;5;12m|[0m[0m [0m[0m[1m[38;5;9m^^^^^^^^^^^^^^^^[0m[0m [0m[0m[1m[38;5;9mmissing `diesel_backend`[0m

[0m[1m[38;5;9merror[E0063][0m[0m[1m: missing field `diesel_backend` in initializer of `GenerationConfig<'_>`[0m
[0m  [0m[0m[1m[38;5;12m--> [0m[0msrc/global.rs:403:1[0m
[0m   [0m[0m[1m[38;5;12m|[0m
[0m[1m[38;5;12m12[0m[0m [0m[0m[1m[38;5;12m|[0m[0m [0m[0mGenerationConfig {[0m
[0m   [0m[0m[1m[38;5;12m|[0m[0m [0m[0m[1m[38;5;9m^^^^^^^^^^^^^^^^[0m[0m [0m[0m[1m[38;5;9mmissing `diesel_backend`[0m

[0m[1m[38;5;9merror[0m[0m[1m: aborting due to 2 previous errors[0m

[0m[1mFor more information about this error, try `rustc --explain E0063`.[0m
Couldn't compile the test.

failures:
    src/global.rs - global::GenerationConfig::options (line 394)

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
```

After:
```
$ cargo test --all-features
running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 1 test
test src/global.rs - global::GenerationConfig::options (line 394) ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.18s
```